### PR TITLE
Fix g-ir-introspection

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -130,11 +130,7 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      SCANNER=$CRAFT_PART_INSTALL/usr/bin/g-ir-scanner
-      sed -i "s#'/usr/lib#os.environ.get\('CRAFT_STAGE'\) + '/usr/lib#g" $SCANNER
-      sed -i 's#"/usr/lib#os.environ.get\("CRAFT_STAGE"\) + "/usr/lib#g' $SCANNER
-      sed -i "s#'/usr/share#os.environ.get\('CRAFT_STAGE'\) + '/usr/share#g" $SCANNER
-      sed -i 's#"/usr/share#os.environ.get\("CRAFT_STAGE"\) + "/usr/share#g' $SCANNER
+      sed -i "s#\([\"\']\)/usr/\([^\"\']*\)#os.environ.get\('CRAFT_STAGE'\) + \1/usr/\2#g" $CRAFT_PART_INSTALL/usr/bin/g-ir-scanner
     build-packages:
       - python3-dev
       - bison

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -131,8 +131,10 @@ parts:
       set -eux
       craftctl default
       SCANNER=$CRAFT_PART_INSTALL/usr/bin/g-ir-scanner
-      sed -i 's#/usr/lib#$CRAFT_STAGE/usr/lib#g' $SCANNER
-      sed -i 's#/usr/share#$CRAFT_STAGE/usr/share#g' $SCANNER
+      sed -i "s#'/usr/lib#os.environ.get\('CRAFT_STAGE'\) + '/usr/lib#g" $SCANNER
+      sed -i 's#"/usr/lib#os.environ.get\("CRAFT_STAGE"\) + "/usr/lib#g' $SCANNER
+      sed -i "s#'/usr/share#os.environ.get\('CRAFT_STAGE'\) + '/usr/share#g" $SCANNER
+      sed -i 's#"/usr/share#os.environ.get\("CRAFT_STAGE"\) + "/usr/share#g' $SCANNER
     build-packages:
       - python3-dev
       - bison


### PR DESCRIPTION
When generating gobject-introspection, the python program g-ir-introspection is patched to find the python modules and other elements at $CRAFT_STAGE. Unfortunately, the environment name is inserted "as is" in the strings, instead of using os.environ to get the value.

This makes fail ATK, because when it tries to execute g-ir-scanner, it can't find one of the python modules that it needs to run.

This patch fixes this, by using os.environ.get('CRAFT_STAGE') instead.