### PR TITLE
Test option doesn't exist in json-glib

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -337,7 +337,6 @@ parts:
       - --prefix=/usr
       - --buildtype=release
       - -Ddocs=false
-      - -Dtests=false
     build-environment: *buildenv
 
   libpsl:


### PR DESCRIPTION
The option 'test' isn't available in the meson_options.txt file, so it must be removed from the part.