### PR TITLE
Libpsl can't find python

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -353,6 +353,10 @@ parts:
     build-packages:
       - libidn2-0-dev
       - libunistring-dev
+    override-pull: |
+      set -eux
+      craftctl default
+      sed -i 's#!/usr/bin/env python#!/usr/bin/env python3#g' src/psl-make-dafsa
 
   libsoup2:
     after: [ libpsl, meson ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -356,7 +356,7 @@ parts:
     override-pull: |
       set -eux
       craftctl default
-      sed -i 's#!/usr/bin/env python#!/usr/bin/env python3#g' src/psl-make-dafsa
+      sed -i 's#^\#!/usr/bin/env python#\#!/usr/bin/env python3#g' src/psl-make-dafsa
 
   libsoup2:
     after: [ libpsl, meson ]


### PR DESCRIPTION
The psl-make-dafsa uses '/usr/bin/env python' to find the python runtime, but that searches for python2.

The documentation specifies that it requires python2.7+, ( https://github.com/rockdaboot/libpsl#readme ) which seems to indicate that it also does work with python3, so this patch changes the previous shebang line to /usr/bin/env python3.