### PR TITLE
Update Pango version to fix Gtk4 build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -254,7 +254,7 @@ parts:
   pango:
     after: [ harfbuzz, meson ]
     source: https://gitlab.gnome.org/GNOME/pango.git
-    source-tag: '1.48.0'
+    source-tag: '1.50.6'
     source-depth: 1
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
The current Pango version is 1.48.0, but in order to buid Gtk4, a precompiled binary, 'pango-view' must be run. This binary is compiled against Pango 1.50.6, which is the version currently available in Ubuntu 22.04, and uses an exported function, 'pango_glyph_string_index_to_x_full()', that was added precisely in Pango 1.50 (https://docs.gtk.org/Pango/struct.GlyphString.html).

This patch updates Pango version to 1.50.6 to fix this.