### PR TITLE
Update Wayland to version 1.20 to avoid file overlapping with Gtk4

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -404,12 +404,13 @@ parts:
   wayland:
     after: [ librest ]
     source: https://gitlab.freedesktop.org/wayland/wayland.git
-    source-tag: '1.19.0'
+    source-tag: '1.20.0'
     source-depth: 1
-    plugin: autotools
-    autotools-configure-parameters:
+    plugin: meson
+    meson-parameters:
       - --prefix=/usr
-      - --disable-documentation
+      - --buildtype=release
+      - -Ddocumentation=false
     build-environment: *buildenv
 
   wayland-protocols:


### PR DESCRIPTION
Ubuntu 22.04 provides Wayland 1.20. Also, Gtk 4.6 comes with some header files from Wayland 1.20. Compiling Wayland 1.19 results in a conflict when Gtk4 and Wayland wants to install the same headers with different contents.

Updating Wayland to version 1.20 partially fixes this.