### PR TITLE
Fix file overlap in Gtk 4

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -497,6 +497,10 @@ parts:
       - libxi-dev
       - libxkbfile-dev
       - libxml2-utils
+    stage:
+      - -usr/bin/wayland-scanner
+      - -usr/lib/*/libwayland-client.so.0.20.0
+      - -usr/lib/*/libwayland-server.so.0.20.0
 
   gtk-locales:
     after: [ gtk3, gtk4 ]


### PR DESCRIPTION
Gtk 4 tries to stage three files that conflicts with others installed by the 'wayland' part. These files are:

    * usr/bin/wayland-scanner
    * usr/lib/x86_64-linux-gnu/libwayland-client.so.0.20.0
    * usr/lib/x86_64-linux-gnu/libwayland-server.so.0.20.0

Since these files really belong to 'wayland', it makes sense to don't stage the ones from 'gtk4'.