### PR TITLE
Add meson as dependency for Wayland

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -402,7 +402,7 @@ parts:
       - gtk-doc-tools
 
   wayland:
-    after: [ librest ]
+    after: [ librest, meson ]
     source: https://gitlab.freedesktop.org/wayland/wayland.git
     source-tag: '1.20.0'
     source-depth: 1


### PR DESCRIPTION
After upgrading Wayland to version 1.20, it must be build using meson. Unfortunately, the dependencies weren't updated.

This patch fixes this by adding 'meson' as a dependency for Wayland.