### PR TITLE
Remove Qt5 backend in libportal

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -520,6 +520,7 @@ parts:
       - --prefix=/usr
       - -Ddocs=false
       - -Dintrospection=false
+      - -Dbackends=['gtk3', 'gtk4']
 
   mm-common:
     after: [ libportal, meson ]


### PR DESCRIPTION
By default, libportal tries to build the Gtk3, Gtk4 and Qt5 backends, but since Qt5 isn't included in the platform snap, it must be removed to allow it to compile.