### PR TITLE
Revert "Temporarily changed build snap channel"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,7 @@ slots:
 parts:
   gnome-sdk:
     plugin: nil
-    stage-snaps: [ gnome-3-38-2004-sdk/latest/edge ]
+    stage-snaps: [ gnome-3-38-2004-sdk/latest/candidate ]
     stage:
       - lib/*/bindtextdomain.so
       - usr


### PR DESCRIPTION
This reverts commit 6ed44b3372af9ce8c71dfe7b0531da22feeff6a1.

I had temporarily made this change, and reverting it so that the platform snap builds the sdk snap that is in candidate.