### PR TITLE
Update pangomm to version 2.46.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -583,7 +583,7 @@ parts:
   pangomm:
     after: [ cairomm, meson ]
     source: https://gitlab.gnome.org/GNOME/pangomm.git
-    source-tag: '2.42.2'
+    source-tag: '2.46.2'
     plugin: meson
     meson-parameters:
       - --prefix=/usr


### PR DESCRIPTION
Pangomm version 2.42.2 fails to compile, returning a missing call (pango_parse_markup()). Upgrading to version 2.46.2, which is also the version being distributed in Ubuntu 22.04, fixes this.