### PR TITLE
Add fontconfig binaries

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
     plugin: nil
     stage-packages:
       - fcitx-frontend-gtk3
+      - fontconfig
       - fonts-noto-color-emoji
       - gir1.2-ggit-1.0
       - gir1.2-gucharmap-2.90


### PR DESCRIPTION
The new gnome extension in snapcraft requires the fc-cache binary, which is available in the 'fontconfig' package.

This MR adds that package to gnome-42-2204.