### PR TITLE
packages: Add libcanberra-gtk3-module

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,6 +64,7 @@ parts:
       - libavahi-common3
       - libbrotli1
       - libc-bin
+      - libcanberra-gtk3-module
       - libcdt5
       - libcgraph6
       - libcolord2


### PR DESCRIPTION
This module is needed for Gtk3 applications.