### PR TITLE
add snapcraft-desktop-integration

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -181,6 +181,14 @@ parts:
         fi
       done
 
+  command-chain:
+    source: https://github.com/snapcore/snapcraft-desktop-integration.git
+    source-type: git
+    source-subdir: gnome
+    plugin: make
+    make-parameters:
+      - PLATFORM_PLUG=$SNAPCRAFT_PROJECT_NAME
+
   cleanup:
     after: [ caches ]
     plugin: nil


### PR DESCRIPTION
This enables command-chains used by the Snapcraft gnome extension.
`source-tag` should be used once the repository becomes stable.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

---
Requires snapcore/snapcraft-desktop-integration#1