### PR TITLE
Fix all PkgConfig files from HarfBuzz in Gnome-42-2204

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -244,10 +244,12 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      PC=$CRAFT_PART_INSTALL/usr/lib/pkgconfig/harfbuzz.pc
-      sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
-      sed -i 's#libdir=/usr#libdir=${prefix}#' $PC
-      sed -i 's#includedir=/usr#includedir=${prefix}#' $PC
+      for PC in $CRAFT_PART_INSTALL/usr/lib/pkgconfig/harfbuzz*.pc;
+      do
+        sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
+        sed -i 's#libdir=/usr#libdir=${prefix}#' $PC
+        sed -i 's#includedir=/usr#includedir=${prefix}#' $PC
+      done
     build-packages:
       - ragel
       - libgraphite2-dev


### PR DESCRIPTION
The PkgConfig files from HarfBuzz must be patched to make them
point easily to $CRAFT_STAGE/usr during the building process,
and to /snap/gnome-42-2204-sdk/current/usr when mounted.

Unfortunately, only one of the four files were being patched.

This MR fixes this.