### PR TITLE
Fix libsoup3

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1069,6 +1069,7 @@ parts:
       - libhogweed6
       - libidn2-0
       - libjpeg-dev
+      - libkrb5-3
       - liblcms2-dev
       - liblzo2-dev
       - libmount-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1064,6 +1064,8 @@ parts:
       - libgnutls30
       - libgspell-1-dev
       - libgudev-1.0-dev
+      - libgvc6
+      - libgraphviz-dev
       - libhogweed6
       - libidn2-0
       - libjpeg-dev
@@ -1086,6 +1088,8 @@ parts:
       - libpython3.10-dev
       - libseccomp-dev
       - libseccomp2
+      - libsigc++-2.0-0v5
+      - libsigc++-2.0-dev
       - libsqlite3-0
       - libsqlite3-dev
       - libtasn1-6

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1073,6 +1073,8 @@ parts:
       - libmozjs-91-dev
       - libmtdev1
       - libnettle8
+      - libnghttp2-14
+      - libnghttp2-dev
       - libnotify-dev
       - libpcre2-8-0
       - libpcre3


### PR DESCRIPTION
When compiling something with libsoup3, libnghttp2 is needed.
But the SDK lacks it, so although the libsoup-3.0.pc and
libraries are inside, pkg-config will say that it isn't available.

This MR fixes it.