### PR TITLE
Fix several broken links

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,7 +23,9 @@ parts:
     stage:
       - lib/*/bindtextdomain.so
       - usr
-      
+      - lib/$CRAFT_ARCH_TRIPLET/*
+      - etc/gnome/*
+
       - -usr/**/*.a
       - -usr/**/*.c
       - -usr/**/*.cpp


### PR DESCRIPTION
There were several broken symlinks at usr/lib/TRIPLET because
they pointed to lib/TRIPLET, but that folder wasn't being
staged/primed.

There was also another broken link to etc/gnome/defaults.list,
again because that folder wasn't being staged/primed.

This MR fixes both.