### PR TITLE
Remove root folder

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1220,6 +1220,7 @@ parts:
     override-prime: |
       set -eux
 
+      rm -rf root
       rm -rf usr/share/doc
       rm -rf usr/share/man
       rm -rf usr/libexec/*/installed-tests


### PR DESCRIPTION
The final snap has a root folder with some unneeded files.
This MR removes it.