### PR TITLE
Add amdgpu.ids file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,6 +26,7 @@ parts:
       - usr
       - lib/$CRAFT_ARCH_TRIPLET/*
       - etc/gnome/*
+      - usr/share/libdrm/amdgpu.ids
 
       - -usr/**/*.a
       - -usr/**/*.c


### PR DESCRIPTION
This file is read when some GTK applications are launched, so
a warning message was being shown.