### PR TITLE
Fix python runtime

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1104,6 +1104,7 @@ parts:
       - libpython3-dev
       - libpython3.10-dev
       - libpython3.10-minimal
+      - libpython3.10-stdlib
       - libseccomp-dev
       - libseccomp2
       - libsigc++-2.0-0v5

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1103,6 +1103,7 @@ parts:
       - libwrap0
       - libpython3-dev
       - libpython3.10-dev
+      - libpython3.10-minimal
       - libseccomp-dev
       - libseccomp2
       - libsigc++-2.0-0v5


### PR DESCRIPTION
The python 3.10 runtime lacks several important files, so
executing it isn't possible unless using part of the resources
of core22. Unfortunately, since meson depends on python, not
having python means no meson too.

This patch fixes this by adding the basic package with the
modules.