### PR TITLE
DT-487 Fix gnome contents 42-2204 building

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -262,6 +262,7 @@ parts:
     build-packages:
       - python3-pip
       - zip
+      - python3-apt
     override-prime: |
       set -eux
 


### PR DESCRIPTION
In the *cleanup* part, it tries to install the python3 module
*craft-parts*. This module depends on the *apt* module to manage
debian packages, and this module depends on DistUtilsExtra.
The problem is that the DistUtilsExtra isn't available in PIP.

Installing the *python3-apt* debian package fixes this, because
PIP will find the *apt* dependency already satisfied.