### PR TITLE
DT-488 Add support for AMDGPU_ASIC_ID_TABLE_PATH

### DIFF
--- a/patches/libdrm.diff
+++ b/patches/libdrm.diff
@@ -1,0 +1,26 @@
+diff --git a/amdgpu/amdgpu_asic_id.c b/amdgpu/amdgpu_asic_id.c
+index a5007ffc..42b8f94c 100644
+--- a/amdgpu/amdgpu_asic_id.c
++++ b/amdgpu/amdgpu_asic_id.c
+@@ -112,12 +112,18 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
+ 	ssize_t n;
+ 	int line_num = 1;
+ 	int r = 0;
++	char *amdgpu_asic_id_table_path;
+ 
+ 	fp = fopen(AMDGPU_ASIC_ID_TABLE, "r");
+ 	if (!fp) {
+-		fprintf(stderr, "%s: %s\n", AMDGPU_ASIC_ID_TABLE,
+-			strerror(errno));
+-		return;
++		amdgpu_asic_id_table_path = getenv("AMDGPU_ASIC_ID_TABLE_PATH");
++		if (amdgpu_asic_id_table_path != NULL)
++			fp = fopen(amdgpu_asic_id_table_path, "r");
++		if (!fp) {
++			fprintf(stderr, "%s: %s\n", AMDGPU_ASIC_ID_TABLE,
++				strerror(errno));
++			return;
++		}
+ 	}
+ 
+ 	/* 1st valid line is file version */

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -889,8 +889,30 @@ parts:
       - libevdev-dev
       - libwacom-dev
 
+  libdrm:
+    after: [ libinput, meson-deps ]
+    source: https://gitlab.freedesktop.org/Mesa/drm.git
+    source-tag: 'libdrm-2.4.110'
+    plugin: meson
+    build-environment: *buildenv
+    meson-parameters:
+      - --prefix=/usr
+      - -Doptimization=3
+      - -Ddebug=true
+      - -Dinstall-test-programs=false
+      - -Dvalgrind=false
+      - -Dman-pages=false
+      - -Dcairo-tests=false
+      - -Dnouveau=true
+      - -Damdgpu=true
+      - -Dintel=true
+    override-pull: |
+      craftctl default
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/libdrm.diff
+
+
   clutter:
-    after: [ cogl, libinput, meson-deps ]
+    after: [ cogl, libinput, meson-deps, libdrm ]
     source: https://gitlab.gnome.org/GNOME/clutter.git
     source-tag: '1.26.4'
     plugin: meson
@@ -904,7 +926,6 @@ parts:
       - -Dpixbuf_tests=false
     build-environment: *buildenv
     build-packages:
-      - libdrm-dev
       - xsltproc
       - libgudev-1.0-dev
     stage:
@@ -1117,7 +1138,6 @@ parts:
       - libcanberra-gtk3-dev
       - libdbus-1-3
       - libdbus-1-dev
-      - libdrm-dev
       - libegl-mesa0
       - libegl1-mesa-dev
       - libexpat1


### PR DESCRIPTION
Every time a GTK-based program is launched in a computer with
an AMD-based GPU, the error

    /usr/share/libdrm/amdgpu.ids: No such file or directory

is shown in the terminal. The reason is that libdrm expects
that file to be in that precise location. Although the file
is now available in Gnome-42-2204, it isn’t accessible
directly, but each snap has to manually add a LAYOUT statement
to link that file from
$SNAP/gnome-contents/usr/share/libdrm to the root.

A possible fix would be to set that LAYOUT statement in
snapcraft, in the "gnome extension" code, but that means that
any snap that wants to include its own libdrm version won't be
able to put its own version of the file.

This patch fixes this by adding a new environment variable to
libdrm: AMDGPU_ASIC_ID_TABLE_PATH. This variable holds the
full path to the file, and it is used only when the file isn't
found in the expected location. Thus any snap that wants to
include its own version of libdrm can also use a LAYOUT
statement to place its own file at /usr/share/libdrm, while the
Gnome Extension snap can use the environment variable to point
to its file.