### PR TITLE
DT-531 update versions and add extra packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -350,7 +350,7 @@ parts:
   librsvg:
     after: [ gdk-pixbuf, vala ]
     source: https://gitlab.gnome.org/GNOME/librsvg.git
-    source-tag: '2.54.4'
+    source-tag: '2.54.5'
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:
@@ -1181,6 +1181,7 @@ parts:
       - appstream
       - appstream-util
       - desktop-file-utils
+      - freeglut3-dev
       - gcc
       - gettext
       - itstool
@@ -1205,6 +1206,7 @@ parts:
       - libgcrypt20
       - libgcrypt20-dev
       - libgl1-mesa-dev
+      - libglu1-mesa-dev
       - libgmp10
       - libgnutls28-dev
       - libgnutls30
@@ -1258,6 +1260,7 @@ parts:
       - libvorbisfile3
       - libwacom9
       - libwebkit2gtk-4.0-dev
+      - libwebkit2gtk-4.1-dev
       - libx11-xcb-dev
       - libxcb-render0-dev
       - libxcb-shm0-dev


### PR DESCRIPTION
Update the software versions in the Gnome 42-2204 SDK snap.

Also add libgtk2webkit-4.1-dev, complementing version 4.0.

Finally, add libglu1-mesa and freeglut3 to remove a warning
when building the corresponding CONTENTS snap.