### PR TITLE
Updated versions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,7 +23,7 @@ parts:
   ninja:
     plugin: nil
     source: https://github.com/ninja-build/ninja.git
-    source-tag: 'v1.11.0'
+    source-tag: 'v1.11.1'
     override-build: |
       rm -rf build
       rm -f ninja
@@ -87,7 +87,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.72.3'
+    source-tag: '2.72.4'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -152,7 +152,7 @@ parts:
   gobject-introspection:
     after: [ cairo, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gobject-introspection.git
-    source-tag: '1.72.0'
+    source-tag: '1.72.1'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -173,7 +173,7 @@ parts:
   vala:
     after: [ gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/vala.git
-    source-tag: '0.56.2'
+    source-tag: '0.56.3'
     plugin: autotools
     autotools-configure-parameters: [ --prefix=/usr ]
     build-environment: *buildenv
@@ -185,7 +185,7 @@ parts:
   gee:
     after: [ vala ]
     source: https://gitlab.gnome.org/GNOME/libgee.git
-    source-tag: '0.20.5'
+    source-tag: '0.20.6'
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters: [ --prefix=/usr ]
@@ -298,7 +298,7 @@ parts:
   pango:
     after: [ harfbuzz, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pango.git
-    source-tag: '1.50.9'
+    source-tag: '1.50.11'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -436,7 +436,7 @@ parts:
   libsoup3:
     after: [ libsoup2, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/libsoup.git
-    source-tag: '3.0.7'
+    source-tag: '3.0.8'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -479,7 +479,7 @@ parts:
   wayland-protocols:
     after: [ wayland, meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.26'
+    source-tag: '1.27'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -531,7 +531,7 @@ parts:
   gtk4:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.6.6'
+    source-tag: '4.6.7'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -614,7 +614,7 @@ parts:
 
   libadwaita:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
-    source-tag: '1.1.4'
+    source-tag: '1.1.5'
     after: [ meson-deps, gtk4 ]
     plugin: meson
     meson-parameters:
@@ -671,7 +671,7 @@ parts:
   glibmm:
     after: [ mm-common ]
     source: https://gitlab.gnome.org/GNOME/glibmm.git
-    source-tag: '2.66.4' # maximum version useful for gtkmm-3.24.
+    source-tag: '2.66.5' # maximum version useful for gtkmm-3.24.
     plugin: autotools
     override-build: |
       set -eux
@@ -707,7 +707,7 @@ parts:
   cairomm:
     after: [ glibmm, meson-deps ]
     source: https://gitlab.freedesktop.org/cairo/cairomm.git
-    source-tag: '1.14.3' # maximum version useful for gtkmm-3.24
+    source-tag: '1.14.4' # maximum version useful for gtkmm-3.24
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -723,7 +723,7 @@ parts:
   pangomm:
     after: [ cairomm, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pangomm.git
-    source-tag: '2.46.2' # maximum version useful for gtkmm-3.24
+    source-tag: '2.46.3' # maximum version useful for gtkmm-3.24
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -764,7 +764,7 @@ parts:
   gtkmm:
     after: [ atkmm, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtkmm.git
-    source-tag: '3.24.6'
+    source-tag: '3.24.7'
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -1079,7 +1079,7 @@ parts:
   gjs:
     after: [ libhandy, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gjs.git
-    source-tag: '1.72.2'
+    source-tag: '1.72.3'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1156,7 +1156,7 @@ parts:
   libgweather:
     after: [ libgeocode, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libgweather.git
-    source-tag: '4.1.0'
+    source-tag: '4.1.1'
     plugin: meson
     build-environment: *buildenv
     meson-parameters:


### PR DESCRIPTION
This patch updates several parts to their latest version, but keeping the major/minor values.

There are several parts that can be updated to bigger minor or even major values:

- meson: from 0.62.2 to 0.63.3
- harfbuzz: from 4.4.1 to 5.3.0
- librsvg: from 2.54.5 to 2.55.1
- libsoup3: from 3.0.8 to 3.2.0
- gtk4: from 4.6.7 to 4.8.1
- poppler: from poppler-22.07.0 to poppler-22.10.0
- libadwaita: from 1.1.5 to 1.2.0
- gtksourceview: from 5.5.1 to 5.6.1
- libpeas: from 1.32.0 to 1.34.0
- libhandy: from 1.6.3 to 1.8.0
- GJS: from 1.72.3 to 1.74.0
- libgweather: from 4.1.1. to 4.2.0