### PR TITLE
Update README for Core22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-git clone -b gnome-3-34-1804-sdk https://gitlab.gnome.org/Community/Ubuntu/gnome-sdk.git gnome-3-34-1804-sdk
+git clone -b gnome-42-2204-sdk https://github.com/ubuntu/gnome-sdk.git gnome-42-2204-sdk


### PR DESCRIPTION
This patch fully fixes the README.md for Gnome-42-2204-sdk.

It overrides https://github.com/ubuntu/gnome-sdk/pull/1