### PR TITLE
DT-777: apply check-portal-plugs-for-snap patch to Core20

### DIFF
--- a/patches/check-for-snap-plugs-before-accessing-portals.patch
+++ b/patches/check-for-snap-plugs-before-accessing-portals.patch
@@ -1,0 +1,455 @@
+diff --git a/gio/gportalsupport.c b/gio/gportalsupport.c
+index b0a94b360..135ffd89d 100644
+--- a/gio/gportalsupport.c
++++ b/gio/gportalsupport.c
+@@ -2,6 +2,8 @@
+  *
+  * Copyright 2016 Red Hat, Inc.
+  *
++ * SPDX-License-Identifier: LGPL-2.1-or-later
++ *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+  * License as published by the Free Software Foundation; either
+@@ -18,84 +20,159 @@
+ 
+ #include "config.h"
+ 
++#include "glib-private.h"
+ #include "gportalsupport.h"
++#include "gsandbox.h"
+ 
+-static gboolean flatpak_info_read;
++static GSandboxType sandbox_type = G_SANDBOX_TYPE_UNKNOWN;
+ static gboolean use_portal;
+ static gboolean network_available;
+ static gboolean dconf_access;
+ 
++#ifdef G_PORTAL_SUPPORT_TEST
++static const char *snapctl = "snapctl";
++#else
++static const char *snapctl = "/usr/bin/snapctl";
++#endif
++
++static gboolean
++snap_plug_is_connected (const gchar *plug_name)
++{
++  gint wait_status;
++  const gchar *argv[] = { snapctl, "is-connected", plug_name, NULL };
++
++  /* Bail out if our process is privileged - we don't want to pass those
++   * privileges to snapctl. It could be overridden and this would
++   * allow arbitrary code execution.
++   */
++  if (GLIB_PRIVATE_CALL (g_check_setuid) ())
++    return FALSE;
++
++  if (!g_spawn_sync (NULL, (gchar **) argv, NULL,
++#ifdef G_PORTAL_SUPPORT_TEST
++                     G_SPAWN_SEARCH_PATH |
++#endif
++                         G_SPAWN_STDOUT_TO_DEV_NULL |
++                         G_SPAWN_STDERR_TO_DEV_NULL,
++                     NULL, NULL, NULL, NULL, &wait_status,
++                     NULL))
++    return FALSE;
++
++  return g_spawn_check_exit_status (wait_status, NULL);
++}
++
+ static void
+-read_flatpak_info (void)
++sandbox_info_read (void)
+ {
+-  const gchar *path = "/.flatpak-info";
++  static gsize sandbox_info_is_read = 0;
+ 
+-  if (flatpak_info_read)
++  /* Sandbox type and Flatpak info is static, so only read once */
++  if (!g_once_init_enter (&sandbox_info_is_read))
+     return;
+ 
+-  flatpak_info_read = TRUE;
++  sandbox_type = glib_get_sandbox_type ();
+ 
+-  if (g_file_test (path, G_FILE_TEST_EXISTS))
+-    {
+-      GKeyFile *keyfile;
+-
+-      use_portal = TRUE;
+-      network_available = FALSE;
+-      dconf_access = FALSE;
+-
+-      keyfile = g_key_file_new ();
+-      if (g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, NULL))
+-        {
+-          char **shared = NULL;
+-          char *dconf_policy = NULL;
+-
+-          shared = g_key_file_get_string_list (keyfile, "Context", "shared", NULL, NULL);
+-          if (shared)
+-            {
+-              network_available = g_strv_contains ((const char * const *)shared, "network");
+-              g_strfreev (shared);
+-            }
+-
+-          dconf_policy = g_key_file_get_string (keyfile, "Session Bus Policy", "ca.desrt.dconf", NULL);
+-          if (dconf_policy)
+-            {
+-              if (strcmp (dconf_policy, "talk") == 0)
+-                dconf_access = TRUE;
+-              g_free (dconf_policy);
+-            }
+-        }
+-
+-      g_key_file_unref (keyfile);
+-    }
+-  else
++  switch (sandbox_type)
+     {
+-      const char *var;
++    case G_SANDBOX_TYPE_FLATPAK:
++      {
++        GKeyFile *keyfile;
++        const char *keyfile_path = "/.flatpak-info";
+ 
+-      var = g_getenv ("GTK_USE_PORTAL");
+-      if (var && var[0] == '1')
+         use_portal = TRUE;
+-      network_available = TRUE;
+-      dconf_access = TRUE;
++        network_available = FALSE;
++        dconf_access = FALSE;
++
++        keyfile = g_key_file_new ();
++
++#ifdef G_PORTAL_SUPPORT_TEST
++        char *test_key_file =
++          g_build_filename (g_get_user_runtime_dir (), keyfile_path, NULL);
++        keyfile_path = test_key_file;
++#endif
++
++        if (g_key_file_load_from_file (keyfile, keyfile_path, G_KEY_FILE_NONE, NULL))
++          {
++            char **shared = NULL;
++            char *dconf_policy = NULL;
++
++            shared = g_key_file_get_string_list (keyfile, "Context", "shared", NULL, NULL);
++            if (shared)
++              {
++                network_available = g_strv_contains ((const char *const *) shared, "network");
++                g_strfreev (shared);
++              }
++
++            dconf_policy = g_key_file_get_string (keyfile, "Session Bus Policy", "ca.desrt.dconf", NULL);
++            if (dconf_policy)
++              {
++                if (strcmp (dconf_policy, "talk") == 0)
++                  dconf_access = TRUE;
++                g_free (dconf_policy);
++              }
++          }
++
++#ifdef G_PORTAL_SUPPORT_TEST
++        g_clear_pointer (&test_key_file, g_free);
++#endif
++
++        g_key_file_unref (keyfile);
++      }
++      break;
++    case G_SANDBOX_TYPE_SNAP:
++      break;
++    case G_SANDBOX_TYPE_UNKNOWN:
++      {
++        const char *var;
++
++        var = g_getenv ("GTK_USE_PORTAL");
++        if (var && var[0] == '1')
++          use_portal = TRUE;
++        network_available = TRUE;
++        dconf_access = TRUE;
++      }
++      break;
+     }
++
++  g_once_init_leave (&sandbox_info_is_read, 1);
+ }
+ 
+ gboolean
+ glib_should_use_portal (void)
+ {
+-  read_flatpak_info ();
++  sandbox_info_read ();
++
++  if (sandbox_type == G_SANDBOX_TYPE_SNAP)
++    return snap_plug_is_connected ("desktop");
++
+   return use_portal;
+ }
+ 
+ gboolean
+ glib_network_available_in_sandbox (void)
+ {
+-  read_flatpak_info ();
++  sandbox_info_read ();
++
++  if (sandbox_type == G_SANDBOX_TYPE_SNAP)
++    {
++      /* FIXME: This is inefficient doing multiple calls to check connections.
++       * See https://github.com/snapcore/snapd/pull/12301 for a proposed
++       * improvement to snapd for this.
++       */
++      return snap_plug_is_connected ("desktop") ||
++        snap_plug_is_connected ("network-status");
++    }
++
+   return network_available;
+ }
+ 
+ gboolean
+ glib_has_dconf_access_in_sandbox (void)
+ {
+-  read_flatpak_info ();
++  sandbox_info_read ();
++
++  if (sandbox_type == G_SANDBOX_TYPE_SNAP)
++    return snap_plug_is_connected ("gsettings");
++
+   return dconf_access;
+ }
+diff --git a/gio/gportalsupport.h b/gio/gportalsupport.h
+index 746f1fd6b..5fe5d8267 100644
+--- a/gio/gportalsupport.h
++++ b/gio/gportalsupport.h
+@@ -2,6 +2,8 @@
+  *
+  * Copyright 2016 Red Hat, Inc.
+  *
++ * SPDX-License-Identifier: LGPL-2.1-or-later
++ *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Lesser General Public
+  * License as published by the Free Software Foundation; either
+@@ -17,6 +19,7 @@
+  */
+ 
+ #ifndef __G_PORTAL_SUPPORT_H__
++#define __G_PORTAL_SUPPORT_H__
+ 
+ #include <glib.h>
+ 
+diff --git a/gio/gsandbox.c b/gio/gsandbox.c
+new file mode 100644
+index 000000000..fcbefa902
+--- /dev/null
++++ b/gio/gsandbox.c
+@@ -0,0 +1,141 @@
++/* GIO - GLib Input, Output and Streaming Library
++ *
++ * Copyright 2022 Canonical Ltd
++ *
++ * SPDX-License-Identifier: LGPL-2.1-or-later
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General
++ * Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include "config.h"
++
++#include "gsandbox.h"
++
++#include <string.h>
++
++#define SNAP_CONFINEMENT_PREFIX "confinement:"
++
++static gboolean
++is_flatpak (void)
++{
++  const char *flatpak_info = "/.flatpak-info";
++  gboolean found;
++
++#ifdef G_PORTAL_SUPPORT_TEST
++        char *test_key_file =
++          g_build_filename (g_get_user_runtime_dir (), flatpak_info, NULL);
++        flatpak_info = test_key_file;
++#endif
++
++  found = g_file_test (flatpak_info, G_FILE_TEST_EXISTS);
++
++#ifdef G_PORTAL_SUPPORT_TEST
++  g_clear_pointer (&test_key_file, g_free);
++#endif
++
++  return found;
++}
++
++static gchar *
++get_snap_confinement (const char  *snap_yaml,
++                      GError     **error)
++{
++  char *confinement = NULL;
++  char *yaml_contents;
++
++  if (g_file_get_contents (snap_yaml, &yaml_contents, NULL, error))
++    {
++      const char *line = yaml_contents;
++
++      do
++        {
++          if (g_str_has_prefix (line, SNAP_CONFINEMENT_PREFIX))
++            break;
++
++          line = strchr (line, '\n');
++          if (line)
++            line += 1;
++        }
++      while (line != NULL);
++
++      if (line)
++        {
++          const char *start = line + strlen (SNAP_CONFINEMENT_PREFIX);
++          const char *end = strchr (start, '\n');
++
++          confinement =
++            g_strstrip (end ? g_strndup (start, end-start) : g_strdup (start));
++        }
++
++      g_free (yaml_contents);
++    }
++
++  return g_steal_pointer (&confinement);
++}
++
++static gboolean
++is_snap (void)
++{
++  GError *error = NULL;
++  const gchar *snap_path;
++  gchar *yaml_path;
++  char *confinement;
++  gboolean result;
++
++  snap_path = g_getenv ("SNAP");
++  if (snap_path == NULL)
++    return FALSE;
++
++  result = FALSE;
++  yaml_path = g_build_filename (snap_path, "meta", "snap.yaml", NULL);
++  confinement = get_snap_confinement (yaml_path, &error);
++  g_free (yaml_path);
++
++  /* Classic snaps are de-facto no sandboxed apps, so we can ignore them */
++  if (!error && g_strcmp0 (confinement, "classic") != 0)
++    result = TRUE;
++
++  g_clear_error (&error);
++  g_free (confinement);
++
++  return result;
++}
++
++/*
++ * glib_get_sandbox_type:
++ *
++ * Gets the type of sandbox this process is running inside.
++ *
++ * Checking for sandboxes may involve doing blocking I/O calls, but should not take
++ * any significant time.
++ *
++ * The sandbox will not change over the lifetime of the process, so calling this
++ * function once and reusing the result is valid.
++ *
++ * If this process is not sandboxed then @G_SANDBOX_TYPE_UNKNOWN will be returned.
++ * This is because this function only detects known sandbox types in #GSandboxType.
++ * It may be updated in the future if new sandboxes come into use.
++ *
++ * Returns: a #GSandboxType.
++ */
++GSandboxType
++glib_get_sandbox_type (void)
++{
++  if (is_flatpak ())
++    return G_SANDBOX_TYPE_FLATPAK;
++  else if (is_snap ())
++    return G_SANDBOX_TYPE_SNAP;
++  else
++    return G_SANDBOX_TYPE_UNKNOWN;
++}
+diff --git a/gio/gsandbox.h b/gio/gsandbox.h
+new file mode 100644
+index 000000000..7861b2756
+--- /dev/null
++++ b/gio/gsandbox.h
+@@ -0,0 +1,47 @@
++/* GIO - GLib Input, Output and Streaming Library
++ *
++ * Copyright 2022 Canonical Ltd
++ *
++ * SPDX-License-Identifier: LGPL-2.1-or-later
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General
++ * Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef __G_SANDBOX_H__
++#define __G_SANDBOX_H__
++
++#include <gio.h>
++
++G_BEGIN_DECLS
++
++/*
++ * GSandboxType:
++ * @G_SANDBOX_TYPE_UNKNOWN: process is running inside an unknown or no sandbox.
++ * @G_SANDBOX_TYPE_FLATPAK: process is running inside a flatpak sandbox.
++ * @G_SANDBOX_TYPE_SNAP: process is running inside a snap sandbox.
++ *
++ * The type of sandbox that processes can be running inside.
++ */
++typedef enum
++{
++  G_SANDBOX_TYPE_UNKNOWN,
++  G_SANDBOX_TYPE_FLATPAK,
++  G_SANDBOX_TYPE_SNAP
++} GSandboxType;
++
++GSandboxType glib_get_sandbox_type (void);
++
++G_END_DECLS
++
++#endif
+diff --git a/gio/meson.build b/gio/meson.build
+index 2ef60eda9..ee23ed9cf 100644
+--- a/gio/meson.build
++++ b/gio/meson.build
+@@ -388,7 +388,9 @@ if host_system != 'windows'
+     'gproxyresolverportal.c',
+     'gtrashportal.c',
+     'gportalsupport.c',
+-    'gportalnotificationbackend.c'),
++    'gportalnotificationbackend.c',
++    'gsandbox.c',
++    ),
+     xdp_dbus_generated
+   ]
+ 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -60,6 +60,10 @@ parts:
     build-environment: *buildenv
     build-environment:
       - CFLAGS: -Wno-nonnull
+    override-pull: |
+      set -eux
+      snapcraftctl pull
+      patch -p1 < $SNAPCRAFT_PROJECT_DIR/patches/check-for-snap-plugs-before-accessing-portals.patch
     override-build: |
       set -eux
       snapcraftctl build


### PR DESCRIPTION
This MR applies to Core20 the GLib MR https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3020

This MR makes GLib to use the keyfile backend with dconf also in Snaps, not only in Flatpak.