### PR TITLE
Update to last versions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,7 +43,7 @@ parts:
     after: [ ninja ]
     plugin: nil
     source: https://github.com/mesonbuild/meson.git
-    source-tag: '0.63.3'
+    source-tag: '0.64.1'
     override-build: |
       python3 -m pip install .
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages
@@ -87,7 +87,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.74.0'
+    source-tag: '2.74.1'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -268,7 +268,7 @@ parts:
   harfbuzz:
     after: [ fribidi ]
     source: https://github.com/harfbuzz/harfbuzz.git
-    source-tag: '5.3.0' # developers declared that they won't break ABI
+    source-tag: '5.3.1' # developers declared that they won't break ABI
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:
@@ -298,7 +298,7 @@ parts:
   pango:
     after: [ harfbuzz, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pango.git
-    source-tag: '1.50.11'
+    source-tag: '1.50.12'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -319,7 +319,7 @@ parts:
   gdk-pixbuf:
     after: [ pango, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gdk-pixbuf.git
-    source-tag: '2.42.9'
+    source-tag: '2.42.10'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -479,7 +479,7 @@ parts:
   wayland-protocols:
     after: [ wayland, meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.27'
+    source-tag: '1.30'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -491,7 +491,7 @@ parts:
   gtk3:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '3.24.34'
+    source-tag: '3.24.35'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -531,7 +531,7 @@ parts:
   gtk4:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.8.1'
+    source-tag: '4.8.2'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -865,7 +865,7 @@ parts:
   gnome-desktop:
     after: [ gsettings-desktop-schemas, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gnome-desktop.git
-    source-tag: '42.5'
+    source-tag: '42.6'
     source-depth: 1
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
GLib can't be updated to 2.74.2 because it breaks GJS build, so it's updated only to 2.74.1

GJS can't be updated to 1.75.1 because it requires LibMozJS-102, but it isn't available in Jammy, so it's kept at the current version.

Poppler could be updated to 22.11, but in GIT, it didn't pass the tests.

LibSoup can be updated to 3.1.4 or to 3.2.2...