### PR TITLE
Drop libappindicator3-1 as we already have libayatana-appindicator3-1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -133,7 +133,6 @@ parts:
       - gir1.2-gucharmap-2.90
       - gir1.2-vte-2.91
       - ibus-gtk3
-      - libappindicator3-1
       - libayatana-appindicator3-1
       - libasound2
       - libasyncns0


### PR DESCRIPTION
Don't stage both, we use libayatana-appindicator3-1 now.  This probably fixes https://github.com/snapcrafters/mattermost-desktop/issues/66