### PR TITLE
Some safe updates.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -521,7 +521,7 @@ parts:
   wayland-protocols:
     after: [ wayland, meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.30'
+    source-tag: '1.31'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -703,7 +703,7 @@ parts:
   mm-common:
     after: [ libportal, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/mm-common.git
-    source-tag: '1.0.4'
+    source-tag: '1.0.5'
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -932,7 +932,7 @@ parts:
   gnome-desktop:
     after: [ gsettings-desktop-schemas, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gnome-desktop.git
-    source-tag: '42.6'
+    source-tag: '42.7'
 # ext:updatesnap
 #   version-format:
 #     same-major: true


### PR DESCRIPTION
Another possibly safe updates are:

  poppler: from 22.10.0 to 22.11.0 or 22.12.0
  pixman: from 0.40.0 to 0.42.2
  libsoup3: from 3.0.8 to 3.2.2
  libinput: from 1.21.0 to 1.22.0
  pycairo: from 1.21.0 to 1.22.0 or 1.23.0