### PR TITLE
Build webp-pixbuf-loader

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1251,6 +1251,19 @@ parts:
     build-packages:
       - gir1.2-glib-2.0
 
+  webp-pixbuf-loader:
+    after: [meson-deps, gdk-pixbuf]
+    source: https://github.com/aruiz/webp-pixbuf-loader.git
+    source-tag: '0.0.7'
+    plugin: meson
+    build-environment: *buildenv
+    meson-parameters:
+      - --prefix=/usr
+      - -Doptimization=3
+      - -Ddebug=true
+    build-packages:
+      - libwebp-dev
+
   debs:
     after: [ libgnome-games-support, libadwaita, libgweather, poppler ]
     plugin: nil
@@ -1373,6 +1386,7 @@ parts:
       - python3.10-venv
       - shared-mime-info
       - zlib1g-dev
+      - libwebp-dev
     override-build: |
       set -eux
       craftctl default


### PR DESCRIPTION
This patch allows GTK apps to be able to parse webp image files.

Overall this ships 2 new files with the snap:

./usr/share/thumbnailers/webp-pixbuf.thumbnailer
./usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-webp.so

The thumbnailer isn't necessarily required and it may be worth removing; however I've kept it as the content snap already seems to have two other thumbnailers, so it would be consistent with what's already there.