### PR TITLE
Add libdir to autotools builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
     build-environment: &buildenv
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/vala-0.56:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:$CRAFT_STAGE/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:$CRAFT_STAGE/usr/lib/pkgconfig:$CRAFT_STAGE/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
       - CRAFT_EXT_CORE_LEVEL: core22
@@ -76,7 +76,9 @@ parts:
 # ext:updatesnap
 #   version-format:
 #     ignore: true
-    autotools-configure-parameters: [ --prefix=/usr ]
+    autotools-configure-parameters:
+      - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
     build-environment: *buildenv
     build-packages:
       - help2man
@@ -208,7 +210,9 @@ parts:
     source: https://gitlab.gnome.org/GNOME/vala.git
     source-tag: '0.56.4'
     plugin: autotools
-    autotools-configure-parameters: [ --prefix=/usr ]
+    autotools-configure-parameters:
+      - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
     build-environment: *buildenv
     build-packages:
       - autoconf-archive
@@ -221,7 +225,9 @@ parts:
     source-tag: '0.20.6'
     source-depth: 1
     plugin: autotools
-    autotools-configure-parameters: [ --prefix=/usr ]
+    autotools-configure-parameters:
+      - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
     build-environment: *buildenv
     override-build: |
       set -eux
@@ -401,6 +407,7 @@ parts:
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
       - --enable-introspection=yes
       - --enable-vala=yes
       - --enable-pixbuf-loader
@@ -514,7 +521,9 @@ parts:
 #     same-minor: true
     source-depth: 1
     plugin: autotools
-    autotools-configure-parameters: [ --prefix=/usr ]
+    autotools-configure-parameters:
+      - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
     build-environment: *buildenv
     build-packages:
       - gtk-doc-tools
@@ -815,7 +824,7 @@ parts:
     build-environment:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
     override-build: |
@@ -841,7 +850,7 @@ parts:
     build-environment:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:$CRAFT_STAGE/usr/lib/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
 
@@ -863,7 +872,7 @@ parts:
     build-environment:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
     override-build: |
@@ -919,6 +928,7 @@ parts:
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
       - --with-builtin=pulse
     build-environment: *buildenv
     build-packages:
@@ -990,6 +1000,7 @@ parts:
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
+      - --libdir=\${exec_prefix}/lib/$CRAFT_ARCH_TRIPLET
       - --enable-wayland-egl-platform=yes
       - --enable-kms-egl-platform=yes
       - --enable-introspection=yes
@@ -1556,10 +1567,10 @@ parts:
       XML2_CONFIG=usr/bin/xml2-config
       sed -i 's#/root/parts/debs/install#/snap/gnome-42-2204-sdk/current#g' $XML2_CONFIG
 
-      rm -f usr/lib/vala-current
+      rm -f usr/lib/$CRAFT_ARCH_TRIPLET/vala-current
       rm -f usr/share/gettext-current
       rm -f usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-current
-      ln -s vala-0.56 usr/lib/vala-current
+      ln -s vala-0.56 usr/lib/$CRAFT_ARCH_TRIPLET/vala-current
       ln -s gettext-0.19.8 usr/share/gettext-current
       ln -s gdk-pixbuf-2.0/2.10.0 usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-current
 


### PR DESCRIPTION
This ensures that the libraries are installed at /usr/lib/TRIPLET.

glibmm and atkmm aren't migrated, because they fail to build.