### PR TITLE
Use local gtk binaries

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -247,14 +247,16 @@ parts:
       - gtk-update-icon-cache
       - libglib2.0-bin
       - shared-mime-info
+    build-environment:
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     override-build: |
       set -eux
       craftctl default
-      /usr/bin/glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
-      /usr/bin/update-mime-database $CRAFT_STAGE/usr/share/mime
+      $CRAFT_STAGE/usr/bin/glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
+      $CRAFT_STAGE/usr/bin/update-mime-database $CRAFT_STAGE/usr/share/mime
       for dir in $CRAFT_STAGE/usr/share/icons/*; do
         if [ -f "$dir/index.theme" ]; then
-          /usr/bin/gtk-update-icon-cache --force "$dir"
+          $CRAFT_STAGE/usr/bin/gtk-update-icon-cache --force "$dir"
         fi
       done
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -250,11 +250,11 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
-      update-mime-database $CRAFT_STAGE/usr/share/mime
+      /usr/bin/glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
+      /usr/bin/update-mime-database $CRAFT_STAGE/usr/share/mime
       for dir in $CRAFT_STAGE/usr/share/icons/*; do
         if [ -f "$dir/index.theme" ]; then
-          gtk-update-icon-cache --force "$dir"
+          /usr/bin/gtk-update-icon-cache --force "$dir"
         fi
       done
 


### PR DESCRIPTION
The "caches" part installs gtk-update-icon-cache, libglib2.0-bin and shared-mime-info .deb packages to use some of their binaries. Unfortunately, the $PATH puts before the built binaries instead of the ones in the system, but the libraries are from the system. This can result in a failure if a new version being compiled requires a new call in the libraries.

In fact, updating in gnome-sdk glib to the last version triggers this problem.

This patch fixes it.