### PR TITLE
Update to GLib 2.76

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -109,11 +109,10 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.74.7'
+    source-tag: '2.76.2'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
-#     lower-than: 2.76.0
     source-depth: 1
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
This PR updates GLib to version 2.76. It should be applied when it is considered safe.