### PR TITLE
Include the fonts configuration from a default desktop installation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -228,8 +228,16 @@ parts:
       find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/{} \;
       find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/{}*" \;
 
+  fonts-config:
+      after: [ debs ]
+      plugin: nil
+      stage-packages: [ fontconfig-config, fonts-arphic-ukai, fonts-arphic-uming, fonts-beng-extra, fonts-dejavu-core, fonts-deva-extra, fonts-droid-fallback, fonts-gubbi, fonts-gujr-extra, fonts-guru-extra, fonts-lohit-beng-assamese, fonts-lohit-beng-bengali, fonts-lohit-deva, fonts-lohit-gujr, fonts-lohit-guru, fonts-lohit-knda, fonts-lohit-mlym, fonts-lohit-orya, fonts-lohit-taml, fonts-lohit-taml-classical, fonts-lohit-telu, fonts-noto-cjk, fonts-noto-mono, fonts-orya-extra, fonts-pagul, fonts-smc-anjalioldlipi, fonts-smc-chilanka, fonts-smc-dyuthi, fonts-smc-karumbi, fonts-smc-keraleeyam, fonts-smc-manjari, fonts-smc-meera, fonts-smc-rachana, fonts-smc-raghumalayalamsans, fonts-smc-suruma, fonts-smc-uroob, fonts-telu-extra, fonts-tlwg-garuda, fonts-tlwg-kinnari, fonts-tlwg-laksaman, fonts-tlwg-loma, fonts-tlwg-mono, fonts-tlwg-norasi, fonts-tlwg-typist, fonts-tlwg-typo, fonts-tlwg-umpush, fonts-tlwg-waree, fonts-urw-base35, language-selector-common ]
+      stage:
+      - etc/fonts
+      - usr/share/fontconfig
+
   caches:
-    after: [ debs ]
+    after: [ fonts-config ]
     plugin: nil
     build-packages:
       - gtk-update-icon-cache


### PR DESCRIPTION
We need at least the URW fonts configuration for correct PDF rendering as reported against firefox on https://github.com/ubuntu/gnome-sdk/issues/49

After discussion we decided to include the configurations provided in a default Ubuntu desktop installation for 42. It's not ideal but should help with consistency with non snaps apps and be an improvement. Going forward we should work with fontconfig upstream on a solution which allows use to import the system configuration instead.