### PR TITLE
Enable building gnome-42-2204-sdk on riscv64

### DIFF
--- a/patches/libffi-enable-building-on-riscv64.patch
+++ b/patches/libffi-enable-building-on-riscv64.patch
@@ -1,0 +1,48 @@
+From 339f603ab6b90df65de5d517ae2f692c35a9cd99 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Date: Mon, 6 Feb 2023 17:28:49 +0100
+Subject: [PATCH 1/1] meson.build: enable building on riscv64
+
+The meson specific files up to now lack support for the RISC-V
+architecture.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi/-/merge_requests/18>
+Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
+Origin: https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi/-/commit/339f603ab6b90df65de5d517ae2f692c35a9cd99
+---
+ include/ffi_noarch.h.meson | 2 ++
+ meson.build                | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/include/ffi_noarch.h.meson b/include/ffi_noarch.h.meson
+index 23bcd9c..5662eef 100644
+--- a/include/ffi_noarch.h.meson
++++ b/include/ffi_noarch.h.meson
+@@ -16,6 +16,8 @@
+ #include "@HEADER@-powerpc.h"
+ #elif defined(__powerpc64__)
+ #include "@HEADER@-powerpc64.h"
++#elif defined (__riscv) && __riscv_xlen == 64
++#include "@HEADER@-riscv64.h"
+ #else
+ #error "Unsupported Architecture"
+ #endif
+diff --git a/meson.build b/meson.build
+index 7aa5fa6..ae7d0aa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -248,6 +248,11 @@ elif host_cpu_family == 'arm'
+   TARGET = 'ARM'
+   c_sources = ['ffi.c']
+   asm_sources = ['sysv.S']
++elif host_cpu_family == 'riscv64'
++  arch_subdir = 'riscv'
++  TARGET = 'RISCV'
++  c_sources = ['ffi.c']
++  asm_sources = ['sysv.S']
+ endif
+ 
+ if TARGET == ''
+-- 
+2.39.2
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -942,6 +942,9 @@ parts:
       - --prefix=/usr
       - --with-builtin=pulse
     build-environment: *buildenv
+    override-build: |
+      ./autogen.sh
+      craftctl default
     build-packages:
       - libasound2-dev
       - libvorbis-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -105,6 +105,9 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
     build-environment: *buildenv
+    override-pull: |
+      craftctl default
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/libffi-enable-building-on-riscv64.patch
 
   glib:
     after: [ libffi, meson-deps ]


### PR DESCRIPTION
With the following changes the gnome-42-2204-sdk snap can be built on riscv64:

* run autogen.sh for libcanberra to replace the outdated config.guess
* use a newer version of libffi including a patch enabling riscv64 builds