### PR TITLE
Some programs, like Cambalache, require Broadway

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -615,7 +615,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
-      - -Dbroadway-backend=false
+      - -Dbroadway-backend=true
       - -Dx11-backend=true
       - -Dwayland-backend=true
       - -Dwin32-backend=false


### PR DESCRIPTION
I'm creating a snap for Cambalache, but it requires Broadway https://gitlab.gnome.org/jpu/cambalache