### PR TITLE
Add pkg-resources module

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1612,6 +1612,7 @@ parts:
       - python3-distutils
       - python3-minimal
       - python3-pip
+      - python3-pkg-resources
       - python3-setuptools
       - python3-venv
       - python3-wheel


### PR DESCRIPTION
For some reason, the pkg-resources module (which is required for setuptools) wasn't being installed, so a lot of programs couldn't be snapped.

This patch fixes it.