### PR TITLE
added `libappstream-dev` package to fix cargs for libadwaita

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1521,6 +1521,7 @@ parts:
     stage-packages:
       - appstream
       - appstream-util
+      - libappstream-dev
       - desktop-file-utils
       - freeglut3
       - freeglut3-dev


### PR DESCRIPTION
This CI is failing due to `appstream.pc` being not available. https://github.com/Sjoerd1993/Graphs/actions/runs/6289897296/job/17141950904?pr=515

This PR will fix it