### PR TITLE
point ppa to ubuntu-asahi/ubuntu-asahi-next.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,7 +26,7 @@ compression: lzo
 
 package-repositories:
   - type: apt
-    ppa: tobhe/asahi
+    ppa: ubuntu-asahi/ubuntu-asahi-next
 
 architectures:
   - arm64


### PR DESCRIPTION
We want to build a new edge snap for each new testing version released and then promote it to stable roughly at the same time we publish a new mesa to the main ppa to keep everything nicely in sync.