### PR TITLE
add libsystemd-dev to debs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1604,6 +1604,7 @@ parts:
       - libsqlite3-dev
       - libstdc++6
       - libsystemd0
+      - libsystemd-dev
       - libtasn1-6
       - libtdb1
       - libthai-dev


### PR DESCRIPTION
Adding `libsystemd-dev` since some gnome 45 snaps are requiring it to build and this might become a build dependency for most of them as they get updated