### PR TITLE
Stage libnvidia-egl-wayland1, fixes lack of accelerated rendering in firefox on wayland with nvidia

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -191,6 +191,7 @@ parts:
       - libwayland-client0
       - libwayland-cursor0
       - libwayland-egl1
+      - libnvidia-egl-wayland1
       - libwebkit2gtk-4.0-37
       - libx11-6
       - libxau6


### PR DESCRIPTION
Requires https://github.com/snapcore/snapcraft-desktop-integration/pull/18