### PR TITLE
Added some more gstreamer related packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1560,9 +1560,16 @@ parts:
       - libgnutls28-dev
       - libgnutls30
       - libgspell-1-dev
-      - libgstreamer-plugins-base1.0-0
-      - libgstreamer-plugins-bad1.0-0
-      - libgstreamer-plugins-good1.0-0
+      - libgstreamer-plugins-base1.0-dev
+      - libgstreamer-plugins-bad1.0-dev
+      - libgstreamer-plugins-good1.0-dev
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-tools
+      - gstreamer1.0-plugins-ugly
+      - gstreamer1.0-pipewire
+      - gstreamer1.0-gl
       - libgudev-1.0-dev
       - libgvc6
       - libgraphviz-dev


### PR DESCRIPTION
1. Development packages for gstreamer for apps building properly
2. gstreamer-gl: for glsinkbin
3. gstreamer-pipewire: for pipewire
4. gstreamer ugly plugins for some codecs
5. gstreamer-tools: some apps use that to test the existence of gstreamer apis and plugins

One package that's necessary, but problematic, is the `gstreamer1.0-libav` package. It needs libavcodec, but fetching it will make the ffmpeg content snap and this content snap itself(probably) to clash.