### PR TITLE
gtk3: gdkglcontext-wayland: Fallback to GLES 2.0 after GL failed 

### DIFF
--- a/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
+++ b/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
@@ -1,0 +1,80 @@
+From 02dcea10b9ba13ecc83667affe49c4226b7bccf1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Mon, 2 Oct 2023 15:32:29 +0200
+Subject: [PATCH] =?UTF-8?q?gdkglcontext-wayland:=20Fallback=20to=20GLES?=
+ =?UTF-8?q?=C2=A02.0=20after=20legacy=20failed?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This lets the NGL backend be selected instead of the Cairo backend on
+devices which expose both GL and GLES, but have better support of GLES.
+
+Tested on a PinePhone.
+
+Backport of aced6030eed169f9c5df2fe9748cb10d8f4cd2cb
+---
+ gdk/wayland/gdkglcontext-wayland.c | 46 +++++++++++++++++++++++++-----
+ 1 file changed, 39 insertions(+), 7 deletions(-)
+
+diff --git a/gdk/wayland/gdkglcontext-wayland.c b/gdk/wayland/gdkglcontext-wayland.c
+index 296e5e0842d..c009ea704ee 100644
+--- a/gdk/wayland/gdkglcontext-wayland.c
++++ b/gdk/wayland/gdkglcontext-wayland.c
+@@ -179,14 +179,46 @@ gdk_wayland_gl_context_realize (GdkGLContext *context,
+                                         : EGL_NO_CONTEXT,
+                           context_attribs);
+ 
+-  /* If context creation failed without the legacy bit, let's try again with it */
+-  if (ctx == NULL && !legacy_bit)
++  /* Regular EGL context creation failed; force the GLES API */
++  if (ctx == NULL)
+     {
+-      /* Ensure that re-ordering does not break the offsets */
+-      g_assert (context_attribs[0] == EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR);
+-      context_attribs[1] = EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR;
+-      context_attribs[3] = 3;
+-      context_attribs[5] = 0;
++      i = 0;
++      context_attribs[i++] = EGL_CONTEXT_MAJOR_VERSION;
++      context_attribs[i++] = 2;
++      context_attribs[i++] = EGL_CONTEXT_MINOR_VERSION;
++      context_attribs[i++] = 0;
++      context_attribs[i++] = EGL_CONTEXT_FLAGS_KHR;
++      context_attribs[i++] = flags & ~EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR;
++      context_attribs[i++] = EGL_NONE;
++      g_assert (i < N_EGL_ATTRS);
++
++      eglBindAPI (EGL_OPENGL_ES_API);
++
++      legacy_bit = FALSE;
++      use_es = TRUE;
++
++      GDK_NOTE (OPENGL, g_message ("eglCreateContext failed, switching to OpenGL ES"));
++      ctx = eglCreateContext (display_wayland->egl_display,
++                              context_wayland->egl_config,
++                              share != NULL ? GDK_WAYLAND_GL_CONTEXT (share)->egl_context
++                                            : EGL_NO_CONTEXT,
++                              context_attribs);
++    }
++
++  /* Both core GL and GLES context creation failed; fall back to a GL context in compatibility profile */
++  if (ctx == NULL)
++    {
++      i = 0;
++      context_attribs[i++] = EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR;
++      context_attribs[i++] = EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR;
++      context_attribs[i++] = EGL_CONTEXT_MAJOR_VERSION;
++      context_attribs[i++] = 3;
++      context_attribs[i++] = EGL_CONTEXT_MINOR_VERSION;
++      context_attribs[i++] = 0;
++      context_attribs[i++] = EGL_CONTEXT_FLAGS_KHR;
++      context_attribs[i++] = flags & ~EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR;
++      context_attribs[i++] = EGL_NONE;
++      g_assert (i < N_EGL_ATTRS);
+ 
+       eglBindAPI (EGL_OPENGL_API);
+ 
+-- 
+GitLab
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -602,7 +602,9 @@ parts:
       - libxi-dev
       - libxkbfile-dev
       - libxml2-utils
-
+    override-pull: |
+      craftctl default
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
 
   gtk4:
     after: [ wayland-protocols, wayland, meson-deps ]


### PR DESCRIPTION
Apply gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch to fix GL and flutter apps on the Raspberry Pi 4 as well as older generation x86_64 hardware.

For reference: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6449