### PR TITLE
snapcraft: Include libpipewire plus the GStreamer pipewire elements

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -132,6 +132,9 @@ parts:
       - gir1.2-ggit-1.0
       - gir1.2-gucharmap-2.90
       - gir1.2-vte-2.91
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-pipewire
       - ibus-gtk3
       - libasound2
       - libasyncns0
@@ -177,6 +180,7 @@ parts:
       - libmtdev1
       - libogg0
       - libpathplan4
+      - libpipewire-0.3-0
       - libpng16-16
       - libpulse0
       - libpython3.10

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -132,6 +132,7 @@ parts:
       - gir1.2-ggit-1.0
       - gir1.2-gucharmap-2.90
       - gir1.2-vte-2.91
+      - gstreamer1.0-gl
       - gstreamer1.0-plugins-base
       - gstreamer1.0-plugins-good
       - gstreamer1.0-pipewire


### PR DESCRIPTION
To make use of the various pipewire-related portal APIs, we need `libpipewire`. Most will also use the `pipewiresrc` GStreamer element.

I've also explicitly staged the "base" and "good" GStreamer plugins. They were already included as as dependencies of other packages, but I think we want to be explicit about including these particular elements in the snap.

Note that to actually use libpipewire, we need to set a number of environment variables. This will require a companion PR to snapcraft-desktop-integration: https://github.com/snapcore/snapcraft-desktop-integration/pull/20
