### PR TITLE
New updates

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -58,7 +58,7 @@ parts:
     after: [ ninja ]
     plugin: nil
     source: https://github.com/mesonbuild/meson.git
-    source-tag: '1.2.3'
+    source-tag: '1.3.1'
     source-depth: 1
     override-build: |
       python3 -m pip install .
@@ -112,7 +112,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.78.1'
+    source-tag: '2.78.4'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -138,7 +138,7 @@ parts:
   pixman:
     after: [ glib, meson-deps ]
     source: https://gitlab.freedesktop.org/pixman/pixman.git
-    source-tag: 'pixman-0.42.2'
+    source-tag: 'pixman-0.43.2'
 # ext:updatesnap
 #   version-format:
 #     format: 'pixman-%M.%m.%R'
@@ -459,7 +459,7 @@ parts:
   libpsl:
     after: [ json-glib, meson-deps ]
     source: https://github.com/rockdaboot/libpsl.git
-    source-tag: '0.21.2'
+    source-tag: '0.21.5'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -551,7 +551,7 @@ parts:
   wayland-protocols:
     after: [ wayland, meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.32'
+    source-tag: '1.33'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -563,7 +563,7 @@ parts:
   gtk3:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '3.24.38'
+    source-tag: '3.24.41'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -609,7 +609,7 @@ parts:
   gtk4:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.12.3'
+    source-tag: '4.12.5'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -675,7 +675,7 @@ parts:
   poppler:
     after: [ cairo, gdk-pixbuf, glib, gobject-introspection, gtk3, meson-deps ]
     source: https://gitlab.freedesktop.org/poppler/poppler.git
-    source-tag: 'poppler-23.11.0'
+    source-tag: 'poppler-24.01.0'
 # ext:updatesnap
 #   version-format:
 #     format: 'poppler-%M.%m.%R'
@@ -707,7 +707,7 @@ parts:
 
   libadwaita:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
-    source-tag: '1.4.0'
+    source-tag: '1.4.2'
     source-depth: 1
     after: [ meson-deps, gtk4 ]
     plugin: meson
@@ -755,7 +755,7 @@ parts:
   mm-common:
     after: [ libportal, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/mm-common.git
-    source-tag: '1.0.5'
+    source-tag: '1.0.6'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -836,7 +836,7 @@ parts:
   pangomm:
     after: [ cairomm, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pangomm.git
-    source-tag: '2.46.3' # maximum version useful for gtkmm-3.24
+    source-tag: '2.46.4' # maximum version useful for gtkmm-3.24
     source-depth: 1
 # ext:updatesnap
 #   version-format:
@@ -863,7 +863,7 @@ parts:
   atkmm:
     after: [ pangomm ]
     source: https://gitlab.gnome.org/GNOME/atkmm.git
-    source-tag: '2.28.3' # maximum version useful for gtkmm-3.24
+    source-tag: '2.28.4' # maximum version useful for gtkmm-3.24
     source-depth: 1
 # ext:updatesnap
 #   version-format:
@@ -1054,7 +1054,7 @@ parts:
     after: [ cogl, meson-deps ]
     source: https://github.com/linuxwacom/libwacom
     source-type: git
-    source-tag: 'libwacom-2.8.0'
+    source-tag: 'libwacom-2.9.0'
 # ext:updatesnap
 #   version-format:
 #     format: 'libwacom-%M.%m.%R'
@@ -1071,7 +1071,7 @@ parts:
   libinput:
     after: [ libwacom, meson-deps ]
     source: https://gitlab.freedesktop.org/libinput/libinput.git
-    source-tag: '1.24.0'
+    source-tag: '1.25.0'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1270,7 +1270,7 @@ parts:
   p11-kit:
     after: [ gjs, meson-deps ]
     source: https://github.com/p11-glue/p11-kit.git
-    source-tag: '0.25.2'
+    source-tag: '0.25.3'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1286,7 +1286,7 @@ parts:
   libsecret:
     after: [ p11-kit, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/libsecret.git
-    source-tag: '0.21.1'
+    source-tag: '0.21.3'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1473,7 +1473,7 @@ parts:
   intel-gmm:
     after: [ libva ]
     source: https://github.com/intel/gmmlib.git
-    source-tag: 'intel-gmmlib-22.3.12'
+    source-tag: 'intel-gmmlib-22.3.17'
 # ext:updatesnap
 #   version-format:
 #     format: 'intel-gmmlib-%M.%m.%R'
@@ -1500,7 +1500,7 @@ parts:
   intel-media-driver:
     after: [ intel-gmm ]
     source: https://github.com/intel/media-driver.git
-    source-tag: 'intel-media-23.4.0'
+    source-tag: 'intel-media-24.1.2'
 # ext:updatesnap
 #   version-format:
 #     format: 'intel-media-%M.%m.%R'


### PR DESCRIPTION
Only webp-pixbuf-loader isn't updated to last version because it requires a newer version of libwebp. I'll check if it's possible to compile it, but in a different MR.

Tested with cheese, chromium, discord, drawing, epiphany, element and zoom.