### PR TITLE
deps: add libsigc++3.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -188,6 +188,7 @@ parts:
       - libpython3.12
       - librsvg2-2
       - libsigc++-2.0-0v5
+      - libsigc++-3.0-0
       - libsndfile1
       - libthai0
       - libtiff6


### PR DESCRIPTION
content snap builds fine, adding `libsigc++3.0-0` since it was required in the sdk and I think it makes sense to bundle it given that the previous version is bundled