### PR TITLE
feat: update for the gnome 46 release

### DIFF
--- a/patches/style-manager-Support-Yaru-accent-colors.patch
+++ b/patches/style-manager-Support-Yaru-accent-colors.patch
@@ -1,3 +1,7 @@
+From: =?utf-8?b?Ik1hcmNvIFRyZXZpc2FuIChUcmV2acOxbyki?= <mail@3v1n0.net>
+Date: Tue, 5 Apr 2022 16:00:46 +0200
+Subject: style-manager: Support Yaru accent colors
+
 Generate the libadwaita color schemes using Yaru accent colors.
 Then, when the Yaru theme is used in the system, use the generated
 variant instead of the default one.
@@ -7,9 +11,28 @@ No theme changes are applied, only the accent color is now matching
 the yaru ones.
 
 Forwarded: not-needed
+---
+ meson_options.txt                                |   4 +
+ src/adw-settings-impl-gsettings.c                |   8 +
+ src/adw-settings-impl-portal.c                   |  25 +++
+ src/adw-settings-impl-private.h                  |  12 ++
+ src/adw-settings-private.h                       |   2 +
+ src/adw-settings.c                               | 198 +++++++++++++++++++++
+ src/adw-style-manager.c                          |  71 +++++++-
+ src/stylesheet/_colors.scss                      |   6 +
+ src/stylesheet/_defaults.scss                    |   7 +-
+ src/stylesheet/_palette-yaru.scss                | 118 +++++++++++++
+ src/stylesheet/adwaita-stylesheet.gresources.xml |   1 +
+ src/stylesheet/meson.build                       |  88 +++++++++-
+ src/stylesheet/sass-utils.scss                   | 212 +++++++++++++++++++++++
+ src/stylesheet/yaru_accent_colors.scss           |  75 ++++++++
+ 14 files changed, 816 insertions(+), 11 deletions(-)
+ create mode 100644 src/stylesheet/_palette-yaru.scss
+ create mode 100644 src/stylesheet/sass-utils.scss
+ create mode 100644 src/stylesheet/yaru_accent_colors.scss
 
 diff --git a/meson_options.txt b/meson_options.txt
-index b95d0ae4..4c51f2a3 100644
+index b95d0ae..2ef9779 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -20,3 +20,7 @@ option('tests',
@@ -20,9 +43,24 @@ index b95d0ae4..4c51f2a3 100644
 +option('yaru-accent-colors',
 +       type: 'boolean', value: true,
 +       description: 'Mimic Yaru accent colors')
-\ No newline at end of file
+diff --git a/src/adw-settings-impl-gsettings.c b/src/adw-settings-impl-gsettings.c
+index 1a2cee3..f2001ff 100644
+--- a/src/adw-settings-impl-gsettings.c
++++ b/src/adw-settings-impl-gsettings.c
+@@ -134,3 +134,11 @@ adw_settings_impl_gsettings_new (gboolean enable_color_scheme,
+ 
+   return ADW_SETTINGS_IMPL (self);
+ }
++
++GSettings *
++adw_settings_impl_gsettings_get_interface_settings (AdwSettingsImpl *self)
++{
++  g_return_val_if_fail (ADW_IS_SETTINGS_IMPL_GSETTINGS (self), NULL);
++
++  return ADW_SETTINGS_IMPL_GSETTINGS (self)->interface_settings;
++}
 diff --git a/src/adw-settings-impl-portal.c b/src/adw-settings-impl-portal.c
-index 9f9fbf7c..be2466e2 100644
+index 9f9fbf7..be2466e 100644
 --- a/src/adw-settings-impl-portal.c
 +++ b/src/adw-settings-impl-portal.c
 @@ -233,3 +233,28 @@ adw_settings_impl_portal_new (gboolean enable_color_scheme,
@@ -55,16 +93,17 @@ index 9f9fbf7c..be2466e2 100644
 +  return read_setting (ADW_SETTINGS_IMPL_PORTAL (self), schema, name, type, out);
 +}
 diff --git a/src/adw-settings-impl-private.h b/src/adw-settings-impl-private.h
-index 54c3f6fb..4aa13854 100644
+index 54c3f6f..04f4893 100644
 --- a/src/adw-settings-impl-private.h
 +++ b/src/adw-settings-impl-private.h
-@@ -42,6 +42,17 @@ void     adw_settings_impl_set_high_contrast (AdwSettingsImpl *self,
+@@ -42,6 +42,18 @@ void     adw_settings_impl_set_high_contrast (AdwSettingsImpl *self,
  
  gboolean adw_get_disable_portal (void);
  
 +gboolean adw_settings_impl_portal_enabled (AdwSettingsImpl *self);
 +
 +#include <gio/gio.h>
++GSettings *adw_settings_impl_gsettings_get_interface_settings (AdwSettingsImpl *self);
 +GDBusProxy *adw_settings_impl_portal_get_proxy (AdwSettingsImpl *self);
 +
 +gboolean adw_settings_impl_portal_read_setting (AdwSettingsImpl  *self,
@@ -77,7 +116,7 @@ index 54c3f6fb..4aa13854 100644
  #define ADW_TYPE_SETTINGS_IMPL_MACOS (adw_settings_impl_macos_get_type())
  
 diff --git a/src/adw-settings-private.h b/src/adw-settings-private.h
-index dc11df58..427470b9 100644
+index dc11df5..427470b 100644
 --- a/src/adw-settings-private.h
 +++ b/src/adw-settings-private.h
 @@ -56,4 +56,6 @@ ADW_AVAILABLE_IN_ALL
@@ -88,20 +127,19 @@ index dc11df58..427470b9 100644
 +
  G_END_DECLS
 diff --git a/src/adw-settings.c b/src/adw-settings.c
-index cf0e81c0..74977791 100644
+index cf0e81c..cf7e319 100644
 --- a/src/adw-settings.c
 +++ b/src/adw-settings.c
-@@ -26,6 +26,9 @@ struct _AdwSettings
+@@ -26,6 +26,8 @@ struct _AdwSettings
    gboolean high_contrast;
    gboolean system_supports_color_schemes;
  
-+  GSettings *interface_settings;
 +  gchar *yaru_accent;
 +
    gboolean override;
    gboolean system_supports_color_schemes_override;
    AdwSystemColorScheme color_scheme_override;
-@@ -39,6 +42,7 @@ enum {
+@@ -39,6 +41,7 @@ enum {
    PROP_SYSTEM_SUPPORTS_COLOR_SCHEMES,
    PROP_COLOR_SCHEME,
    PROP_HIGH_CONTRAST,
@@ -109,7 +147,7 @@ index cf0e81c0..74977791 100644
    LAST_PROP,
  };
  
-@@ -132,6 +136,198 @@ register_impl (AdwSettings     *self,
+@@ -132,6 +135,178 @@ register_impl (AdwSettings     *self,
    }
  }
  
@@ -146,11 +184,16 @@ index cf0e81c0..74977791 100644
 +update_yaru_accent_from_gsettings (AdwSettings *self)
 +{
 +  g_autofree char *theme_name = NULL;
++  GSettings *interface_settings;
 +
-+  if (!self->interface_settings)
++  if (!self->gsettings_impl)
 +    return FALSE;
 +
-+  theme_name = g_settings_get_string (self->interface_settings, "gtk-theme");
++  interface_settings = adw_settings_impl_gsettings_get_interface_settings (self->gsettings_impl);
++  if G_UNLIKELY (!interface_settings)
++    return FALSE;
++
++  theme_name = g_settings_get_string (interface_settings, "gtk-theme");
 +  update_yaru_accent_from_theme (self, theme_name);
 +
 +  return TRUE;
@@ -245,30 +288,10 @@ index cf0e81c0..74977791 100644
 +  return ADW_YARU_ACCENT_SOURCE_NONE;
 +}
 +
-+static gboolean
-+is_running_in_flatpak (void)
-+{
-+  return g_file_test ("/.flatpak-info", G_FILE_TEST_EXISTS);
-+}
-+
 +static void
 +init_yaru_accents (AdwSettings *self)
 +{
 +  AdwYaruAccentSource accent_source;
-+
-+  if (!is_running_in_flatpak ())
-+    {
-+      GSettingsSchemaSource *source;
-+      g_autoptr(GSettingsSchema) schema = NULL;
-+
-+      source = g_settings_schema_source_get_default ();
-+      schema = g_settings_schema_source_lookup (source,
-+                                                "org.gnome.desktop.interface",
-+                                                TRUE);
-+
-+      if (schema && g_settings_schema_has_key (schema, "gtk-theme"))
-+        self->interface_settings = g_settings_new ("org.gnome.desktop.interface");
-+    }
 +
 +  accent_source = update_yaru_accent (self);
 +
@@ -287,7 +310,7 @@ index cf0e81c0..74977791 100644
 +      break;
 +
 +    case ADW_YARU_ACCENT_SOURCE_GSETTINGS:
-+      g_signal_connect_object (self->interface_settings,
++      g_signal_connect_object (adw_settings_impl_gsettings_get_interface_settings (self->gsettings_impl),
 +                               "changed::gtk-theme",
 +                               G_CALLBACK (update_yaru_accent_from_gsettings),
 +                               self, G_CONNECT_SWAPPED);
@@ -295,48 +318,33 @@ index cf0e81c0..74977791 100644
 +
 +    case ADW_YARU_ACCENT_SOURCE_NONE:
 +    default:
-+      g_warning ("No source found for Yaru accent color");
++      g_debug ("No source found for Yaru accent color");
 +      break;
 +  }
-+
-+  if (accent_source != ADW_YARU_ACCENT_SOURCE_GSETTINGS)
-+    g_clear_object (&self->interface_settings);
 +}
-+
-+
 +
  static void
  adw_settings_constructed (GObject *object)
  {
-@@ -155,17 +351,7 @@ adw_settings_constructed (GObject *object)
-     register_impl (self, self->platform_impl, &found_color_scheme, &found_high_contrast);
+@@ -166,6 +341,8 @@ adw_settings_constructed (GObject *object)
    }
  
--  if (!found_color_scheme || !found_high_contrast) {
--    self->gsettings_impl = adw_settings_impl_gsettings_new (!found_color_scheme, !found_high_contrast);
--    register_impl (self, self->gsettings_impl, &found_color_scheme, &found_high_contrast);
--  }
--
--  if (!found_color_scheme || !found_high_contrast) {
--    self->legacy_impl = adw_settings_impl_legacy_new (!found_color_scheme, !found_high_contrast);
--    register_impl (self, self->legacy_impl, &found_color_scheme, &found_high_contrast);
--  }
--
--  self->system_supports_color_schemes = found_color_scheme;
+   self->system_supports_color_schemes = found_color_scheme;
++
 +  init_yaru_accents (self);
  }
  
  static void
-@@ -176,6 +362,8 @@ adw_settings_dispose (GObject *object)
-   g_clear_object (&self->platform_impl);
+@@ -177,6 +354,8 @@ adw_settings_dispose (GObject *object)
    g_clear_object (&self->gsettings_impl);
    g_clear_object (&self->legacy_impl);
-+  g_clear_object (&self->interface_settings);
-+  g_clear_pointer (&self->yaru_accent, g_free);
  
++  g_clear_pointer (&self->yaru_accent, g_free);
++
    G_OBJECT_CLASS (adw_settings_parent_class)->dispose (object);
  }
-@@ -201,6 +389,10 @@ adw_settings_get_property (GObject    *object,
+ 
+@@ -201,6 +380,10 @@ adw_settings_get_property (GObject    *object,
      g_value_set_boolean (value, adw_settings_get_high_contrast (self));
      break;
  
@@ -347,7 +355,7 @@ index cf0e81c0..74977791 100644
    default:
      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
    }
-@@ -231,6 +423,13 @@ adw_settings_class_init (AdwSettingsClass *klass)
+@@ -231,6 +414,13 @@ adw_settings_class_init (AdwSettingsClass *klass)
                            FALSE,
                            G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
  
@@ -361,7 +369,7 @@ index cf0e81c0..74977791 100644
    g_object_class_install_properties (object_class, LAST_PROP, props);
  }
  
-@@ -321,6 +520,8 @@ adw_settings_end_override (AdwSettings *self)
+@@ -321,6 +511,8 @@ adw_settings_end_override (AdwSettings *self)
      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_COLOR_SCHEME]);
    if (notify_hc)
      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_HIGH_CONTRAST]);
@@ -370,7 +378,7 @@ index cf0e81c0..74977791 100644
  }
  
  void
-@@ -375,3 +576,9 @@ adw_settings_override_high_contrast (AdwSettings *self,
+@@ -375,3 +567,9 @@ adw_settings_override_high_contrast (AdwSettings *self,
  
    g_object_notify_by_pspec (G_OBJECT (self), props[PROP_HIGH_CONTRAST]);
  }
@@ -381,7 +389,7 @@ index cf0e81c0..74977791 100644
 +  return self->yaru_accent;
 +}
 diff --git a/src/adw-style-manager.c b/src/adw-style-manager.c
-index d27ebda5..59da0dcb 100644
+index d27ebda..f9f3250 100644
 --- a/src/adw-style-manager.c
 +++ b/src/adw-style-manager.c
 @@ -70,6 +70,7 @@ enum {
@@ -392,7 +400,7 @@ index d27ebda5..59da0dcb 100644
    LAST_PROP,
  };
  
-@@ -155,18 +156,47 @@ update_stylesheet (AdwStyleManager *self)
+@@ -155,18 +156,48 @@ update_stylesheet (AdwStyleManager *self)
      if (adw_settings_get_high_contrast (self->settings))
        gtk_css_provider_load_from_resource (self->provider,
                                             "/org/gnome/Adwaita/styles/base-hc.css");
@@ -407,6 +415,7 @@ index d27ebda5..59da0dcb 100644
    if (self->colors_provider) {
 +    g_autofree char *style = NULL;
 +    g_autofree char *variant = NULL;
++
      if (self->dark)
 -      gtk_css_provider_load_from_resource (self->colors_provider,
 -                                           "/org/gnome/Adwaita/styles/defaults-dark.css");
@@ -444,7 +453,7 @@ index d27ebda5..59da0dcb 100644
    }
  
    self->animation_timeout_id =
-@@ -227,6 +257,14 @@ notify_high_contrast_cb (AdwStyleManager *self)
+@@ -227,6 +258,14 @@ notify_high_contrast_cb (AdwStyleManager *self)
    g_object_notify_by_pspec (G_OBJECT (self), props[PROP_HIGH_CONTRAST]);
  }
  
@@ -459,7 +468,7 @@ index d27ebda5..59da0dcb 100644
  static void
  adw_style_manager_constructed (GObject *object)
  {
-@@ -289,6 +327,11 @@ adw_style_manager_constructed (GObject *object)
+@@ -289,6 +328,11 @@ adw_style_manager_constructed (GObject *object)
                             G_CALLBACK (notify_high_contrast_cb),
                             self,
                             G_CONNECT_SWAPPED);
@@ -471,7 +480,7 @@ index d27ebda5..59da0dcb 100644
  
    update_dark (self);
    update_stylesheet (self);
-@@ -336,6 +379,10 @@ adw_style_manager_get_property (GObject    *object,
+@@ -336,6 +380,10 @@ adw_style_manager_get_property (GObject    *object,
      g_value_set_boolean (value, adw_style_manager_get_high_contrast (self));
      break;
  
@@ -482,7 +491,7 @@ index d27ebda5..59da0dcb 100644
    default:
      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
    }
-@@ -468,6 +515,21 @@ adw_style_manager_class_init (AdwStyleManagerClass *klass)
+@@ -468,6 +516,21 @@ adw_style_manager_class_init (AdwStyleManagerClass *klass)
                            FALSE,
                            G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
  
@@ -505,7 +514,7 @@ index d27ebda5..59da0dcb 100644
  }
  
 diff --git a/src/stylesheet/_colors.scss b/src/stylesheet/_colors.scss
-index 32df08f8..118b5e5b 100644
+index 32df08f..e6865fa 100644
 --- a/src/stylesheet/_colors.scss
 +++ b/src/stylesheet/_colors.scss
 @@ -127,3 +127,9 @@ $strong_disabled_opacity: 0.3;
@@ -518,9 +527,8 @@ index 32df08f8..118b5e5b 100644
 +  $link_color: gtkcolor(yaru_link_color);
 +  $link_visited_color: gtkcolor(yaru_link_visited_color);
 +}
-\ No newline at end of file
 diff --git a/src/stylesheet/_defaults.scss b/src/stylesheet/_defaults.scss
-index 76cc94d5..8a0f88cd 100644
+index 76cc94d..8a0f88c 100644
 --- a/src/stylesheet/_defaults.scss
 +++ b/src/stylesheet/_defaults.scss
 @@ -8,10 +8,13 @@
@@ -541,7 +549,7 @@ index 76cc94d5..8a0f88cd 100644
  @define-color destructive_bg_color #{if($variant == 'dark', "@red_4", "@red_3")};
 diff --git a/src/stylesheet/_palette-yaru.scss b/src/stylesheet/_palette-yaru.scss
 new file mode 100644
-index 00000000..6b335a22
+index 0000000..a943a2e
 --- /dev/null
 +++ b/src/stylesheet/_palette-yaru.scss
 @@ -0,0 +1,118 @@
@@ -663,9 +671,8 @@ index 00000000..6b335a22
 +@define-color dark_3 #{$dark_3};
 +@define-color dark_4 #{$dark_4};
 +@define-color dark_5 #{$dark_5};
-\ No newline at end of file
 diff --git a/src/stylesheet/adwaita-stylesheet.gresources.xml b/src/stylesheet/adwaita-stylesheet.gresources.xml
-index 98a07acf..0d86a06f 100644
+index 98a07ac..0d86a06 100644
 --- a/src/stylesheet/adwaita-stylesheet.gresources.xml
 +++ b/src/stylesheet/adwaita-stylesheet.gresources.xml
 @@ -5,6 +5,7 @@
@@ -677,7 +684,7 @@ index 98a07acf..0d86a06f 100644
      <file>assets/bullet-symbolic.symbolic.png</file>
      <file>assets/bullet@2-symbolic.symbolic.png</file>
 diff --git a/src/stylesheet/meson.build b/src/stylesheet/meson.build
-index 56466c1c..8f56cccc 100644
+index 56466c1..8f56ccc 100644
 --- a/src/stylesheet/meson.build
 +++ b/src/stylesheet/meson.build
 @@ -2,14 +2,66 @@ fs = import('fs')
@@ -801,7 +808,7 @@ index 56466c1c..8f56cccc 100644
      # List in order of preference
 diff --git a/src/stylesheet/sass-utils.scss b/src/stylesheet/sass-utils.scss
 new file mode 100644
-index 00000000..4055eb81
+index 0000000..f7ea2c9
 --- /dev/null
 +++ b/src/stylesheet/sass-utils.scss
 @@ -0,0 +1,212 @@
@@ -1017,10 +1024,9 @@ index 00000000..4055eb81
 +
 +    @return $fg;
 +}
-\ No newline at end of file
 diff --git a/src/stylesheet/yaru_accent_colors.scss b/src/stylesheet/yaru_accent_colors.scss
 new file mode 100644
-index 00000000..a1aa8ee7
+index 0000000..a1aa8ee
 --- /dev/null
 +++ b/src/stylesheet/yaru_accent_colors.scss
 @@ -0,0 +1,75 @@

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,9 +29,10 @@ parts:
     build-environment: &buildenv
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
-      - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:$CRAFT_STAGE/usr/lib/pkgconfig:$CRAFT_STAGE/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:$CRAFT_STAGE/usr/lib/pkgconfig:$CRAFT_STAGE/usr/share/pkgconfig:/usr/share/pkgconfig:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:/usr/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+      - CMAKE_MODULE_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/cmake:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/cmake
       - CRAFT_EXT_CORE_LEVEL: core22
 
   ninja:
@@ -58,7 +59,7 @@ parts:
     after: [ ninja ]
     plugin: nil
     source: https://github.com/mesonbuild/meson.git
-    source-tag: '1.2.3'
+    source-tag: '1.4.0'
     source-depth: 1
     override-build: |
       python3 -m pip install .
@@ -73,7 +74,8 @@ parts:
 
   libtool:
     source: https://git.savannah.gnu.org/git/libtool.git
-    source-tag: 'v2.4.7'
+    source-tag: 'v2.4.6'
+    source-depth: 1
     plugin: autotools
 # ext:updatesnap
 #   version-format:
@@ -112,7 +114,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.78.1'
+    source-tag: '2.78.2'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -126,19 +128,20 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/glib-2.0/
-      cp $CRAFT_PART_INSTALL/usr/bin/{gio-querymodules,glib-compile-schemas} $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/glib-2.0/
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0/
+      cp $CRAFT_PART_INSTALL/usr/bin/{gio-querymodules,glib-compile-schemas} $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/glib-2.0/
     build-packages:
       - pkg-config
       - libmount-dev
       - gcc
       - g++
       - clang
+      - python3-packaging
 
   pixman:
     after: [ glib, meson-deps ]
     source: https://gitlab.freedesktop.org/pixman/pixman.git
-    source-tag: 'pixman-0.42.2'
+    source-tag: 'pixman-0.43.4'
 # ext:updatesnap
 #   version-format:
 #     format: 'pixman-%M.%m.%R'
@@ -208,9 +211,9 @@ parts:
       - flex
 
   vala:
-    after: [ gobject-introspection ]
+    after: [ gobject-introspection, libtool ]
     source: https://gitlab.gnome.org/GNOME/vala.git
-    source-tag: '0.56.14'
+    source-tag: '0.56.16'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
@@ -261,9 +264,9 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      PC=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/atk.pc
+      PC=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/atk.pc
       sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
-      sed -i 's#libdir=/usr/lib/$CRAFT_ARCH_TRIPLET#libdir=${prefix}/lib/$CRAFT_ARCH_TRIPLET#' $PC
+      sed -i 's#libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#libdir=${prefix}/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#' $PC
       sed -i 's#includedir=/usr/include#includedir=${prefix}/include#' $PC
 
   at-spi2-core:
@@ -320,7 +323,7 @@ parts:
   harfbuzz:
     after: [ fribidi, meson-deps ]
     source: https://github.com/harfbuzz/harfbuzz.git
-    source-tag: '8.3.0' # developers declared that they won't break ABI
+    source-tag: '8.3.1' # developers declared that they won't break ABI
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -335,13 +338,13 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/harfbuzz*.pc;
+      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/harfbuzz*.pc;
       do
         sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
         sed -i 's#libdir=/usr#libdir=${prefix}#' $PC
         sed -i 's#includedir=/usr#includedir=${prefix}#' $PC
       done
-      for f in `find $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET |grep \\.la`; do
+      for f in `find $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR |grep \\.la`; do
         sed -i "s#^libdir='/usr/lib#libdir='$CRAFT_STAGE/usr/lib#g" $f
       done
     build-packages:
@@ -351,7 +354,7 @@ parts:
   pango:
     after: [ harfbuzz, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pango.git
-    source-tag: '1.51.1'
+    source-tag: '1.52.1'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -391,12 +394,12 @@ parts:
       set -eux
       craftctl default
       cp $CRAFT_PART_INSTALL/usr/bin/gdk-pixbuf-query-loaders $CRAFT_STAGE/usr/bin/
-      LOADERS_PATH=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders
+      LOADERS_PATH=$CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders
       $CRAFT_PART_INSTALL/usr/bin/gdk-pixbuf-query-loaders $LOADERS_PATH/*.so > $LOADERS_PATH.cache
       # workaround for thumbnailer being in a different directory in the snap env
       sed -i 's#/usr/bin/##' $CRAFT_PART_INSTALL/usr/share/thumbnailers/gdk-pixbuf-thumbnailer.thumbnailer
     organize:
-      usr/bin/gdk-pixbuf-query-loaders: usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders
+      usr/bin/gdk-pixbuf-query-loaders: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders
     build-packages:
       - libpng-dev
       - libjpeg-dev
@@ -459,13 +462,13 @@ parts:
   libpsl:
     after: [ json-glib, meson-deps ]
     source: https://github.com/rockdaboot/libpsl.git
-    source-tag: '0.21.2'
+    source-tag: '0.21.5'
     source-depth: 1
     plugin: meson
     meson-parameters:
       - --prefix=/usr
       - -Druntime=libidn2
-      #- -Dtests=false # available in master, not in 0.21.2
+      - -Dtests=false
       - -Doptimization=3
       - -Ddebug=true
     build-environment: *buildenv
@@ -551,7 +554,7 @@ parts:
   wayland-protocols:
     after: [ wayland, meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.32'
+    source-tag: '1.34'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -586,8 +589,8 @@ parts:
       - -Dexamples=false
     build-environment: *buildenv
     organize:
-      usr/lib/gtk-3.0: usr/lib/$CRAFT_ARCH_TRIPLET/gtk-3.0
-      usr/bin/gtk-query-immodules-3.0: usr/lib/$CRAFT_ARCH_TRIPLET/libgtk-3-0/gtk-query-immodules-3.0
+      usr/lib/gtk-3.0: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gtk-3.0
+      usr/bin/gtk-query-immodules-3.0: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgtk-3-0/gtk-query-immodules-3.0
     build-packages:
       - libxkbcommon-dev
       - libxinerama-dev
@@ -606,10 +609,68 @@ parts:
       craftctl default
       patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
 
+  shaderc:
+    source: https://github.com/google/shaderc.git
+    source-tag: 'v2024.0'
+    source-depth: 1
+    plugin: cmake
+    build-environment: *buildenv
+    override-pull: |
+      craftctl default
+      sed -i "0,/'--quiet',/s/'--quiet',/'--depth',\ '500',/" utils/git-sync-deps
+      ./utils/git-sync-deps
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSHADERC_SKIP_TESTS=ON
+      - -DSHADERC_SKIP_EXAMPLES=ON
+      - -DSHADERC_ENABLE_WGSL_OUTPUT=OFF
+    build-packages:
+      - spirv-tools
+      - spirv-headers
+      - spirv-cross
+
+  vulkan-headers:
+    after: [ wayland-protocols ]
+    source: https://github.com/KhronosGroup/Vulkan-Headers.git
+    source-tag: 'v1.3.280'
+    source-depth: 1
+    plugin: cmake
+    build-environment: *buildenv
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTS=OFF
+    build-packages:
+      - libx11-dev
+      - libxcb1-dev
+      - libxrandr-dev
+      - pkg-config
+
+  vulkan-loaders:
+    after: [ wayland, wayland-protocols, vulkan-headers ]
+    source: https://github.com/KhronosGroup/Vulkan-Loader.git
+    source-tag: 'v1.3.280'
+    source-depth: 1
+    plugin: cmake
+    build-environment: *buildenv
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      - -DLOADER_CODEGEN=ON
+      - -DBUILD_TESTS=OFF
+    build-packages:
+      - libx11-dev
+      - libxcb1-dev
+      - libxrandr-dev
+      - pkg-config
+
+
   gtk4:
-    after: [ wayland-protocols, wayland, meson-deps ]
+    after: [ wayland-protocols, wayland, meson-deps, vulkan-loaders, vulkan-headers, shaderc ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.12.3'
+    source-tag: '4.14.0'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -637,7 +698,7 @@ parts:
       - -Dprint-cups=enabled
     build-environment: *buildenv
     organize:
-      usr/lib/gtk-4.0: usr/lib/$CRAFT_ARCH_TRIPLET/gtk-4.0
+      usr/lib/gtk-4.0: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gtk-4.0
     build-packages:
       - libxkbcommon-dev
       - libcups2-dev
@@ -675,7 +736,7 @@ parts:
   poppler:
     after: [ cairo, gdk-pixbuf, glib, gobject-introspection, gtk3, meson-deps ]
     source: https://gitlab.freedesktop.org/poppler/poppler.git
-    source-tag: 'poppler-23.11.0'
+    source-tag: 'poppler-24.03.0'
 # ext:updatesnap
 #   version-format:
 #     format: 'poppler-%M.%m.%R'
@@ -707,7 +768,7 @@ parts:
 
   libadwaita:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
-    source-tag: '1.4.0'
+    source-tag: '1.5.0'
     source-depth: 1
     after: [ meson-deps, gtk4 ]
     plugin: meson
@@ -755,7 +816,7 @@ parts:
   mm-common:
     after: [ libportal, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/mm-common.git
-    source-tag: '1.0.5'
+    source-tag: '1.0.6'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -852,7 +913,7 @@ parts:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
       - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
     override-build: |
       set -eux
@@ -878,8 +939,8 @@ parts:
     build-environment:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:$CRAFT_STAGE/usr/lib/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$CRAFT_STAGE/usr/lib/vala-0.56${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
 
   gtkmm:
@@ -902,8 +963,8 @@ parts:
     build-environment:
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - M4PATH: $CRAFT_STAGE/usr/lib/glibmm-2.4/proc/m4
     override-build: |
       set -eux
@@ -914,7 +975,7 @@ parts:
   gtksourceview:
     after: [ gtkmm, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtksourceview.git
-    source-tag: '5.10.0'
+    source-tag: '5.12.0'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -1052,9 +1113,8 @@ parts:
 
   libwacom:
     after: [ cogl, meson-deps ]
-    source: https://github.com/linuxwacom/libwacom
-    source-type: git
-    source-tag: 'libwacom-2.8.0'
+    source: https://github.com/linuxwacom/libwacom.git
+    source-tag: 'libwacom-2.10.0'
 # ext:updatesnap
 #   version-format:
 #     format: 'libwacom-%M.%m.%R'
@@ -1071,7 +1131,7 @@ parts:
   libinput:
     after: [ libwacom, meson-deps ]
     source: https://gitlab.freedesktop.org/libinput/libinput.git
-    source-tag: '1.24.0'
+    source-tag: '1.25.0'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1206,7 +1266,7 @@ parts:
   pycairo:
     after: [ libpeas, meson-deps ]
     source: https://github.com/pygobject/pycairo.git
-    source-tag: 'v1.25.1'
+    source-tag: 'v1.26.0'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1218,7 +1278,7 @@ parts:
   pygobject:
     after: [ pycairo, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pygobject.git
-    source-tag: '3.46.0'
+    source-tag: '3.48.1'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1230,7 +1290,7 @@ parts:
   libhandy:
     after: [ pygobject, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/libhandy.git
-    source-tag: '1.8.2'
+    source-tag: '1.8.3'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1259,10 +1319,10 @@ parts:
       - -Dskip_gtk_tests=true
       - -Dskip_dbus_tests=true
       - -Dinstalled_tests=false
+    build-environment: *buildenv
     override-pull: |
       craftctl default
       patch -p1 < $CRAFT_PROJECT_DIR/patches/meson-Fix-GJS.patch
-    build-environment: *buildenv
     build-packages:
       - dbus
       - libmozjs-102-dev
@@ -1270,7 +1330,7 @@ parts:
   p11-kit:
     after: [ gjs, meson-deps ]
     source: https://github.com/p11-glue/p11-kit.git
-    source-tag: '0.25.2'
+    source-tag: '0.25.3'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1286,7 +1346,7 @@ parts:
   libsecret:
     after: [ p11-kit, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/libsecret.git
-    source-tag: '0.21.1'
+    source-tag: '0.21.4'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1354,14 +1414,41 @@ parts:
     override-pull: |
       craftctl default
       patch -p1 < $CRAFT_PROJECT_DIR/patches/libgweather.diff
-      sed -i 's#CRAFT_ENV_REPLACE#/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET#' $CRAFT_PART_SRC/data/meson.build
+      sed -i 's#CRAFT_ENV_REPLACE#/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#' $CRAFT_PART_SRC/data/meson.build
     build-packages:
       - gir1.2-glib-2.0
 
+  freeglut:
+    source: https://github.com/freeglut/freeglut.git
+    source-tag: 'v3.4.0'
+    source-depth: 1
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+    build-packages:
+      - libglu1-mesa-dev
+      - libgl-dev
+
+  libwebp:
+    after: [ freeglut ]
+    source: https://chromium.googlesource.com/webm/libwebp.git
+    source-tag: 'v1.3.2'
+    source-depth: 1
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+    build-packages:
+      - libgif-dev
+      - libjpeg-dev
+      - libpng-dev
+      - libtiff-dev
+
   webp-pixbuf-loader:
-    after: [meson-deps, gdk-pixbuf]
+    after: [meson-deps, gdk-pixbuf, libwebp]
     source: https://github.com/aruiz/webp-pixbuf-loader.git
-    source-tag: '0.2.4'
+    source-tag: '0.2.7'
     source-depth: 1
     plugin: meson
     build-environment: *buildenv
@@ -1369,8 +1456,6 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
-    build-packages:
-      - libwebp-dev
 
   libayatana-ido:
     after: [glib, gtk3]
@@ -1396,7 +1481,7 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/*.pc;
+      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/*.pc;
       do
         sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
         sed -i 's#libdir=/usr#libdir=${prefix}#' $PC
@@ -1446,7 +1531,7 @@ parts:
     override-build: |
       set -eux
       craftctl default
-      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/*.pc;
+      for PC in $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/*.pc;
       do
         sed -i 's#exec_prefix=/usr#exec_prefix=${prefix}#' $PC
         sed -i 's#libdir=/usr#libdir=${prefix}#' $PC
@@ -1456,7 +1541,7 @@ parts:
   libva:
     after: [ libtool, meson-deps, libayatana-appindicator ]
     source: https://github.com/intel/libva.git
-    source-tag: '2.20.0'
+    source-tag: '2.21.0'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1473,7 +1558,7 @@ parts:
   intel-gmm:
     after: [ libva ]
     source: https://github.com/intel/gmmlib.git
-    source-tag: 'intel-gmmlib-22.3.12'
+    source-tag: 'intel-gmmlib-22.3.18'
 # ext:updatesnap
 #   version-format:
 #     format: 'intel-gmmlib-%M.%m.%R'
@@ -1485,13 +1570,13 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
     override-stage: |
-      if [ "$CRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ]; then
+      if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" = "x86_64-linux-gnu" ]; then
         craftctl default
-        sed -i 's#prefix=$CRAFT_STAGE/usr#prefix=$CRAFT_STAGE/usr#' $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/igdgmm.pc
-        sed -i 's#includedir=/usr/include/igdgmm#includedir=${prefix}/include/igdgmm#' $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/igdgmm.pc
+        sed -i 's#prefix=$CRAFT_STAGE/usr#prefix=$CRAFT_STAGE/usr#' $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/igdgmm.pc
+        sed -i 's#includedir=/usr/include/igdgmm#includedir=${prefix}/include/igdgmm#' $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/igdgmm.pc
       fi
     override-build: |
-      if [ "$CRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ]; then
+      if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" = "x86_64-linux-gnu" ]; then
         craftctl default
       else
         echo 'Disabled for this architecture'
@@ -1500,7 +1585,7 @@ parts:
   intel-media-driver:
     after: [ intel-gmm ]
     source: https://github.com/intel/media-driver.git
-    source-tag: 'intel-media-23.4.0'
+    source-tag: 'intel-media-24.1.5'
 # ext:updatesnap
 #   version-format:
 #     format: 'intel-media-%M.%m.%R'
@@ -1515,7 +1600,7 @@ parts:
       - pkg-config
       - cmake
     override-build: |
-      if [ "$CRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ]; then
+      if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" = "x86_64-linux-gnu" ]; then
         craftctl default
       else
         echo 'Disabled for this architecture'
@@ -1529,8 +1614,6 @@ parts:
       - appstream-util
       - libappstream-dev
       - desktop-file-utils
-      - freeglut3
-      - freeglut3-dev
       - gcc
       - gettext
       - itstool
@@ -1652,7 +1735,6 @@ parts:
       - python3.10-venv
       - shared-mime-info
       - zlib1g-dev
-      - libwebp-dev
     override-build: |
       set -eux
       craftctl default
@@ -1660,9 +1742,9 @@ parts:
       find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/{} \;
       find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/{}*" \;
       cd $CRAFT_STAGE/usr/lib
-      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/{} \;
-      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/{}*" \;
-      cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET
+      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{} \;
+      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{}*" \;
+      cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/{} \;
       find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/{}*" \;
 
@@ -1700,8 +1782,8 @@ parts:
         sed -i 's#/etc/#/snap/gnome-42-2204-sdk/current/etc/#g' $PC
       done
 
-      if [ "$CRAFT_ARCH_TRIPLET" = "x86_64-linux-gnu" ]; then
-        sed -i 's#includedir=${prefix}/snap/gnome-42-2204-sdk/current#includedir=${prefix}#' $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/igdgmm.pc
+      if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" = "x86_64-linux-gnu" ]; then
+        sed -i 's#includedir=${prefix}/snap/gnome-42-2204-sdk/current#includedir=${prefix}#' $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/igdgmm.pc
       fi
 
       sed -i 's#/usr/bin/python#python3#' usr/bin/glib-mkenums
@@ -1718,7 +1800,7 @@ parts:
       sed -i 's#/usr/local/share#/snap/gnome-42-2204-sdk/current/usr/local/share#g' $ITSTOOL
       sed -i 's#/usr/share#/snap/gnome-42-2204-sdk/current/usr/share#g' $ITSTOOL
 
-      GDK_PIXBUF_PATH=usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0
+      GDK_PIXBUF_PATH=usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0
       LOADERS=$GDK_PIXBUF_PATH/2.10.0/loaders.cache
       rm -f $CRAFT_PRIME/$GDK_PIXBUF_PATH/2.10.0/loaders/*.so
       cp -a $CRAFT_STAGE/$GDK_PIXBUF_PATH/2.10.0/loaders/*.so $CRAFT_PRIME/$GDK_PIXBUF_PATH/2.10.0/loaders/
@@ -1731,15 +1813,15 @@ parts:
 
       rm -f usr/lib/vala-current
       rm -f usr/share/gettext-current
-      rm -f usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-current
+      rm -f usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-current
       ln -s vala-0.56 usr/lib/vala-current
       ln -s gettext-0.19.8 usr/share/gettext-current
-      ln -s gdk-pixbuf-2.0/2.10.0 usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-current
+      ln -s gdk-pixbuf-2.0/2.10.0 usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-current
 
       # Fix dangling symlink by overwriting it
-      ln -sf lib/$CRAFT_ARCH_TRIPLET/libc_malloc_debug.so.0 usr/lib/$CRAFT_ARCH_TRIPLET/libc_malloc_debug.so
+      ln -sf lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0 usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so
       # CHECK THIS When changing the core base, this line must be update
-      cp /snap/$CRAFT_EXT_CORE_LEVEL/current/lib/$CRAFT_ARCH_TRIPLET/libc_malloc_debug.so.0 lib/$CRAFT_ARCH_TRIPLET/
+      cp /snap/$CRAFT_EXT_CORE_LEVEL/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0 lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
 
   # Used by the gnome snapcraft extensions to load translations from within the content snap
   bindtextdomain:
@@ -1747,8 +1829,8 @@ parts:
     plugin: nil
     override-build: |
       set -eux
-      mkdir -p $CRAFT_PART_INSTALL/lib/$CRAFT_ARCH_TRIPLET
-      gcc -Wall -O2 -o $CRAFT_PART_INSTALL/lib/$CRAFT_ARCH_TRIPLET/bindtextdomain.so -fPIC -shared $CRAFT_PROJECT_DIR/tools/bindtextdomain.c -ldl
+      mkdir -p $CRAFT_PART_INSTALL/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      gcc -Wall -O2 -o $CRAFT_PART_INSTALL/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/bindtextdomain.so -fPIC -shared $CRAFT_PROJECT_DIR/tools/bindtextdomain.c -ldl
 
   cleanup:
     after: [ conditioning ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -114,7 +114,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.78.2'
+    source-tag: '2.78.4'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -566,7 +566,7 @@ parts:
   gtk3:
     after: [ wayland-protocols, wayland, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '3.24.38'
+    source-tag: '3.24.41'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -633,7 +633,7 @@ parts:
   vulkan-headers:
     after: [ wayland-protocols ]
     source: https://github.com/KhronosGroup/Vulkan-Headers.git
-    source-tag: 'v1.3.280'
+    source-tag: 'v1.3.281'
     source-depth: 1
     plugin: cmake
     build-environment: *buildenv
@@ -650,7 +650,7 @@ parts:
   vulkan-loaders:
     after: [ wayland, wayland-protocols, vulkan-headers ]
     source: https://github.com/KhronosGroup/Vulkan-Loader.git
-    source-tag: 'v1.3.280'
+    source-tag: 'v1.3.281'
     source-depth: 1
     plugin: cmake
     build-environment: *buildenv
@@ -670,7 +670,7 @@ parts:
   gtk4:
     after: [ wayland-protocols, wayland, meson-deps, vulkan-loaders, vulkan-headers, shaderc ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.14.0'
+    source-tag: '4.14.1'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -1306,7 +1306,7 @@ parts:
   gjs:
     after: [ libhandy, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gjs.git
-    source-tag: '1.76.2'
+    source-tag: '1.76.3'
 # ext:updatesnap
 #   version-format:
 #     same-minor: true
@@ -1396,7 +1396,7 @@ parts:
   libgweather:
     after: [ libgeocode, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libgweather.git
-    source-tag: '4.4.0'
+    source-tag: '4.4.2'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true


### PR DESCRIPTION
1. removed all the deprecated part environment variables
2. meson => 1.4.0
3. libtool => 2.4.6 (downgrade due to build issues in vala, clashing with local installations)
4. glib => 2.78.4 (2.79+ is advised to be avoided due to circular dependencies in the gnome discourse)
5. pixman => pixman-0.43.4
6. vala => 0.56.16
7. harfbuzz => 8.3.1
8. pango => 1.52.1
9. libpsl => 0.21.5
10. wayland-protocols => 1.34
11. gtk3 => 3.24.41
12. gtk4 => 4.14.1 (gnome team says 4.14.1 is the release, but we avoided odd minor, so skipped it)
13. poppler => poppler-24.03.0
14. libadwaita => 1.5.0 (also updated the patch from the ubuntu patch in debian salsa)
15. mm-common => 1.0.6
16. libwacom => libawacom-2.10.0
17. libinput => 1.25.0
18. pycairo => v1.26.0
19. pygobject => 3.48.1
20. libhandy => 1.8.3
21. p11-kit => 0.25.3
22. libsecret => 0.21.4
23. webp-pixbuf-loaders => 0.2.7
24. libva => 2.21.0
25. intel-gmm => intel-gmmlib-22.3.18
26. libgweather => 4.4.2
27. gjs => 1.76.3

Added builds from source:

**needed by gtk4 4.14.1**
1. shaderc
2. vulkan-loaders
3. vulkan-headers 

**needed by webp-pixbuf-loaders**
1. freeglut
2. libwebp

Requested by Nickvision Apps, Mousam and Dosage Tracker.

Closes #161 