### PR TITLE
Enable introspection in the glib part build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -122,6 +122,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
+      - -Dintrospection=enabled
     build-environment: *buildenv
     override-build: |
       set -eux
@@ -134,6 +135,9 @@ parts:
       - gcc
       - g++
       - clang
+# Use the packages rather than the gobject-introspection part to avoid a depends cycle
+      - gir1.2-glib-2.0-dev
+      - gobject-introspection
 
   pixman:
     after: [ glib, meson-deps ]


### PR DESCRIPTION
The bindings moved between those components upstream this cycle.

We are using build-packages for gobject-introspection instead of using the local part to avoid a dependency loop, we could also build glib once without introspection/don't stage that one but it seems that if the distro g-i version is recent enough it's simpler to just use it