### PR TITLE
ci: add build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build-test
+on:
+  pull_request:
+  push:
+    branches:
+      - gnome-42-2204-sdk
+      - gnome-46-2404-sdk
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'snap'
+        path: ${{ steps.snapcraft.outputs.snap}}


### PR DESCRIPTION
I realized build-test isn't part of the ci for the sdk. Is there a reason for that? This is useful to detect regressions.
Adding it to the content snap is a challenge because it depends on the sdk