### PR TITLE
Don't stage libigdgmm-dev, it's not required and doesn't exist on armhf

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1481,11 +1481,12 @@ parts:
       - zlib1g-dev
       - zlib1g
       - libwebp-dev
-      - libigdgmm-dev
       - libpoppler-dev
       - libpoppler-glib-dev
       - gir1.2-poppler-0.18
-      
+      # the package is intel specific
+      - on amd64:
+        - libigdgmm-dev
     override-build: |
       set -eux
       craftctl default


### PR DESCRIPTION
It was added as part of !221 and it breaking arm builds since the package is intel specific. Afaik the sdk was building before so it shouldn't be really required?