### PR TITLE
Update some libraries names to match the ones used in Noble

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1353,7 +1353,7 @@ parts:
       - libcairo2-dev
       - libcanberra-gtk3-dev
       - libcrypt1
-      - libcurl4
+      - libcurl4t64
       - libcurl4-openssl-dev
       - libdbus-1-3
       - libdbus-1-dev
@@ -1400,7 +1400,7 @@ parts:
       - libmount-dev
       - libmount1
       - libmozjs-102-dev
-      - libmtdev1
+      - libmtdev1t64
       - libnettle8t64
       - libnghttp2-14
       - libnghttp2-dev


### PR DESCRIPTION
Those libraries got renamed for the t64 transition. The new library Provides the old name on !armhf so that isn't an issue on the other architectures but leads to a build error on armhf