### PR TITLE
Add libpolkit-gobject-1-0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1653,6 +1653,7 @@ parts:
       - shared-mime-info
       - zlib1g-dev
       - libwebp-dev
+      - libpolkit-gobject-1-0
       - libpolkit-gobject-1-dev
     override-build: |
       set -eux


### PR DESCRIPTION
Otherwise libpolkit-gobject-1.so is a dangling link to libpolkit-gobject-1.so.0.0.0.

Expands #227.

Rationale
---------

If the package (libpolkit-gobject-1-0) is not present in the stage-packages it will not be included in the snap even if it is a dependency of a stage-package (libpolkit-gobject-1-dev). Also the [build log of the gnome-sdk](https://launchpadlibrarian.net/738931725/buildlog_snap_ubuntu_jammy_amd64_gnome-42-2204-sdk_BUILDING.txt.gz) makes me wonder if it is being pulled at all, as I see no reference to the *-0, only to the *-dev in it.

Bug
---

Gnome software snap [attempts to link this library statically instead of dynamically](https://code.launchpad.net/~desktop-snappers/+snap/snap-store-stable/+build/2583953/+files/buildlog_snap_ubuntu_jammy_amd64_snap-store-stable_BUILDING.txt.gz) because the .so is a dangling link while the .a is the real thing.