### PR TITLE
Update libmozjs to 115

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1404,7 +1404,7 @@ parts:
       - liblzma5
       - libmount-dev
       - libmount1
-      - libmozjs-102-dev
+      - libmozjs-115-dev
       - libmtdev1t64
       - libnettle8t64
       - libnghttp2-14


### PR DESCRIPTION
GJS is built with libmozjs-115-dev, but in the dependencies for the SDK itself the old limbozjs-102-dev is used. This PR fixes this.