### PR TITLE
Delete broken links

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -298,3 +298,5 @@ parts:
       find . -type d -empty -delete
 
       ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+      # delete any broken link
+      find . -xtype l -delete


### PR DESCRIPTION
After the "mesa cleanup", libraries are removed but not some soft links to them, so they remain, but are broken.

This patch removes all the broken links.