### PR TITLE
fix: libsrvg needs curl to fetch rust

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -366,6 +366,7 @@ parts:
     build-environment: *buildenv
     build-packages:
       - libssl-dev
+      - curl
     override-pull: |
       craftctl default
       # cargo version in .deb is too old


### PR DESCRIPTION
Added curl to build-packages for librsvg as it needs to use curl to setup rust
