### PR TITLE
Update the gdk-pixbuf loaders

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -260,7 +260,12 @@ parts:
       craftctl default
       $CRAFT_STAGE/usr/bin/glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
       $CRAFT_STAGE/usr/bin/update-mime-database $CRAFT_STAGE/usr/share/mime
+
       # the icons cache is rebuilt in 'cleanup' priming because it is there where the duplicated icons are removed
+
+      export CACHE=$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders/* > $CACHE
+      sed -i "s@$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0@g" $CACHE
 
   command-chain:
     source: https://github.com/snapcore/snapcraft-desktop-integration.git


### PR DESCRIPTION
Currently, the `loaders.cache` file in the `gdk-pixbuf` folder contains wrong paths, because it is generated during the `sdk` build phase. This is not a problem for snaps making use of gnome-XX-YYYY because the extensions script defines two environment variables and regenerates a new `loaders.cache`file. But in the case of core-desktop this approach seems to not work, so this patch ensures that the default `loaders.cache` file is correct when `layout` is used to map the gdk-pixbuf-2.0/2.10.0 folder in the root filesystem.