### PR TITLE
Don't delete index.theme files in icons folder

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -260,11 +260,7 @@ parts:
       craftctl default
       $CRAFT_STAGE/usr/bin/glib-compile-schemas $CRAFT_STAGE/usr/share/glib-2.0/schemas
       $CRAFT_STAGE/usr/bin/update-mime-database $CRAFT_STAGE/usr/share/mime
-      for dir in $CRAFT_STAGE/usr/share/icons/*; do
-        if [ -f "$dir/index.theme" ]; then
-          $CRAFT_STAGE/usr/bin/gtk-update-icon-cache --force "$dir"
-        fi
-      done
+      # the icons cache is rebuilt in 'cleanup' priming because it is there where the duplicated icons are removed
 
   command-chain:
     source: https://github.com/snapcore/snapcraft-desktop-integration.git
@@ -289,8 +285,13 @@ parts:
       set -eux
 
       cd /snap/gtk-common-themes/current
-      find . -type f,l -exec rm -f $CRAFT_PRIME/usr/{} \;
+      find . -type f,l ! -name index.theme -exec rm -f $CRAFT_PRIME/usr/{} \;
       cd $CRAFT_PRIME
+      for dir in usr/share/icons/*; do
+        if [ -f "$dir/index.theme" ]; then
+          gtk-update-icon-cache --force "$dir"
+        fi
+      done
 
       rm -rf usr/share/doc
       rm -rf usr/share/man

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -289,7 +289,7 @@ parts:
       cd $CRAFT_PRIME
       for dir in usr/share/icons/*; do
         if [ -f "$dir/index.theme" ]; then
-          gtk-update-icon-cache --force "$dir"
+          $CRAFT_STAGE/usr/bin/gtk-update-icon-cache --force "$dir"
         fi
       done
 


### PR DESCRIPTION
The index.theme file is required to regenerate the icon cache, so it must be preserved when checking for duplicated files.

This patch does this, thus allowing to regenerate the icons cache after duplicates have been removed, thus ensuring that only really-available icons will be added to the cache.