### PR TITLE
Fix glib-mkenums

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1547,7 +1547,7 @@ parts:
         sed -i 's#includedir=${prefix}/snap/gnome-46-2404-sdk/current#includedir=${prefix}#' $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/igdgmm.pc
       fi
 
-      sed -i 's#/usr/bin/python#python3#' usr/bin/glib-mkenums
+      sed -i 's#/usr/bin/python$#python3#' usr/bin/glib-mkenums
 
       LIBTOOLIZE=usr/bin/libtoolize
       sed -i 's#pkgauxdir="$CRAFT_STAGE#pkgauxdir="/snap/gnome-46-2404-sdk/current#' $LIBTOOLIZE

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1547,8 +1547,6 @@ parts:
         sed -i 's#includedir=${prefix}/snap/gnome-46-2404-sdk/current#includedir=${prefix}#' $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig/igdgmm.pc
       fi
 
-      sed -i 's#/usr/bin/python$#python3#' usr/bin/glib-mkenums
-
       LIBTOOLIZE=usr/bin/libtoolize
       sed -i 's#pkgauxdir="$CRAFT_STAGE#pkgauxdir="/snap/gnome-46-2404-sdk/current#' $LIBTOOLIZE
       sed -i 's#pkgltdldir="$CRAFT_STAGE#pkgltdldir="/snap/gnome-46-2404-sdk/current#' $LIBTOOLIZE


### PR DESCRIPTION
The 'conditioning' part is replacing '/usr/bin/python' in glib- mkenums file with '/usr/bin/python3', to ensure that it works with the current builds. Unfortunately, this only works if the original shebang was referring to python2. The current version of glib-mkenums, instead, has a shebang that already points to python3, so the result of the sed command is a shebang that points to python33, resulting in an execution error.

This patch fixes it by ensuring that the replacement is done only if the shebang points to "python", but not if it points to "python3".

Fix https://github.com/ubuntu/gnome-sdk/issues/260