### PR TITLE
Disable all tests and documentation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -149,6 +149,8 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
       - -Dgtk=disabled
+      - -Dtests=disabled
+      - -Ddemos=disabled
     build-environment: *buildenv
 
   cairo:
@@ -198,6 +200,7 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
       - -Dgtk_doc=false
+      - -Ddoctool=enabled
     build-environment: *buildenv
     override-build: |
       set -eux
@@ -256,6 +259,7 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
       - -Ddocs=false
+      - -Dtests=false
     build-environment: *buildenv
 
   harfbuzz:
@@ -271,6 +275,8 @@ parts:
       - -Dgobject=enabled
       - -Doptimization=3
       - -Ddebug=true
+      - -Dtests=disabled
+      - -Ddocs=disabled
       - --default-library=both
     build-environment: *buildenv
     override-build: |
@@ -386,6 +392,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
+      - -Dtests=false
     build-environment: *buildenv
     build-packages:
       - libgl1-mesa-dev
@@ -403,6 +410,9 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
       - -Dgtk_doc=disabled
+      - -Dintrospection=enabled
+      - -Ddocumentation=disabled
+      - -Dtests=false
     build-environment: *buildenv
 
   libpsl:
@@ -414,7 +424,7 @@ parts:
     meson-parameters:
       - --prefix=/usr
       - -Druntime=libidn2
-      #- -Dtests=false # available in master, not in 0.21.2
+      - -Dtests=false
       - -Doptimization=3
       - -Ddebug=true
     build-environment: *buildenv
@@ -438,6 +448,9 @@ parts:
       - -Ddebug=true
       - -Dvapi=enabled
       - -Dtls_check=false #disable build time check, but we need to ensure glib-networking is available at runtime
+      - -Dintrospection=enabled
+      - -Ddocs=disabled
+      - -Dtests=false
     build-environment: *buildenv
     build-packages:
       - libsqlite3-dev
@@ -503,6 +516,7 @@ parts:
       - -Dbuiltin_immodules=yes
       - -Ddemos=false
       - -Dexamples=false
+      - -Dtests=false
     build-environment: *buildenv
     organize:
       usr/lib/gtk-3.0: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gtk-3.0
@@ -808,6 +822,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
+      - -Dintrospection=enabled
     build-environment: *buildenv
     build-packages:
       - gettext
@@ -964,6 +979,7 @@ parts:
       - -Doptimization=3
       - -Ddebug=true
       - -Ddocumentation=false
+      - -Dtests=false
     build-environment: *buildenv
     build-packages:
       - check
@@ -1098,6 +1114,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
+      - -Dtests=false
     build-environment: *buildenv
 
   pygobject:
@@ -1110,6 +1127,7 @@ parts:
       - --prefix=/usr
       - -Doptimization=3
       - -Ddebug=true
+      - -Dtests=false
     build-environment: *buildenv
 
   libhandy:
@@ -1126,6 +1144,8 @@ parts:
       - -Dtests=false
       - -Dexamples=false
       - -Dglade_catalog=disabled
+      - -Dintrospection=enabled
+      - -Dvapi=true
     build-environment: *buildenv
 
   gjs:
@@ -1161,6 +1181,7 @@ parts:
       - -Ddebug=true
       - -Dhash_impl=internal
       - -Dtrust_paths=/etc/ssl/certs/ca-certificates.crt
+      - -Dtest=false
     build-packages:
       - libtasn1-6-dev
     build-environment: *buildenv
@@ -1610,6 +1631,7 @@ parts:
 
       rm -rf root
       rm -rf usr/share/doc
+      rm -rf usr/share/gtk-doc
       rm -rf usr/share/man
       rm -rf usr/libexec/*/installed-tests
       rm -rf usr/libexec/installed-tests


### PR DESCRIPTION
This PR disables, during the building of parts, all the tests and documentation build, and also enables building gobject introspection data and VAPI files, to ensure that all libraries are available in any language.

It also removes the usr/share/gtk-doc folder, since it's not needed.

All this saves a little bit of space and slightly reduces the build time.