### PR TITLE
Revert librsvg to version 2.58.1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -345,36 +345,27 @@ parts:
       - libtiff-dev
 
   librsvg:
-    after: [ gdk-pixbuf, vala, meson-deps ]
+    after: [ gdk-pixbuf, vala ]
     source: https://gitlab.gnome.org/GNOME/librsvg.git
-    source-tag: '2.59.1' # they left the odd->unstable even->stable scheme, and now tags are stable
+    source-tag: '2.58.1' # they left the odd->unstable even->stable scheme, and now tags are stable
 # ext:updatesnap
 #   version-format:
 #     no-9x-revisions: true
     source-depth: 1
-    plugin: meson
-    meson-parameters:
+    plugin: autotools
+    autotools-configure-parameters:
       - --prefix=/usr
-      - -Doptimization=3
-      - -Ddebug=true
-      - -Dintrospection=enabled
-      - -Dvala=enabled
-      - -Dpixbuf=enabled
-      - -Dpixbuf-loader=enabled
-      - -Ddocs=disabled
-      - -Dtests=false
+      - --enable-introspection=yes
+      - --enable-vala=yes
+      - --enable-pixbuf-loader
     build-environment: *buildenv
     build-packages:
-      - libssl-dev
-      - curl
-    override-pull: |
+      - cargo
+    override-stage: |
+      set -eux
       craftctl default
-      # cargo version in .deb is too old
-      curl https://sh.rustup.rs -sSf > cargo.sh
-      sh ./cargo.sh -y
-      export PATH=$PATH:$HOME/.cargo/bin
-      ~/.cargo/bin/cargo install cargo-c
-      cp ~/.cargo/bin/* /usr/local/bin
+      # snapcraft is adding twice $CRAFT_STAGE
+      cp -a $CRAFT_STAGE/$CRAFT_STAGE/* $CRAFT_STAGE/
 
   epoxy:
     after: [ librsvg, meson-deps ]


### PR DESCRIPTION
This is required because version 2.59.1 changes the name of the gdk-pixbuf-loader from libpixbufloader-svg.so to
libpixbufloader_svg.so, which breaks snaps because each snap stores its own loaders.cache file with the path for each loader, so an already installed snap will have a loaders.cache file with a svg loader path pointing to the former name, but the current file would be the later, thus it won't be able to load any svg.

Reverting the version also forces to revert from meson to autotools.

The right solution is to modify snapcraft-desktop-integration scripts to add a check that rebuilds any cache (not only pixbuf loaders, but also fonts, icons...) not only if the snap itself is updated, but also if any of the extensions is updated too.

Fix https://github.com/ubuntu/gnome-sdk/issues/257