### PR TITLE
Use .deb libtool instead of savannah version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -72,17 +72,13 @@ parts:
       - python3-pip
 
   libtool:
-    source: https://git.savannah.gnu.org/git/libtool.git
-    source-tag: 'v2.4.7'
-    plugin: autotools
+    plugin: nil
 # ext:updatesnap
 #   version-format:
 #     ignore: true
-    autotools-configure-parameters: [ --prefix=/usr ]
-    build-environment: *buildenv
-    build-packages:
-      - help2man
-      - texinfo
+    stage-packages:
+      - libtool
+      - libtool-bin
     override-stage: |
       set -eux
       craftctl default
@@ -969,6 +965,7 @@ parts:
       - libtdb-dev
       - libpulse-dev
       - libgstreamer1.0-dev
+      - libltdl-dev
 
   gsound:
     after: [ libcanberra, meson-deps ]
@@ -1577,6 +1574,7 @@ parts:
       - libjpeg-dev
       - libkrb5-3
       - liblcms2-dev
+      - libltdl-dev
       - liblzo2-dev
       - libmount-dev
       - libmount1


### PR DESCRIPTION
This is to avoid the downloading problems we are having from the Savannah git repo from GNU.