### PR TITLE
libadwaita/patches: Add wartybrown accent color

### DIFF
--- a/patches/stylesheet-Add-wartybrown-accent-color.patch
+++ b/patches/stylesheet-Add-wartybrown-accent-color.patch
@@ -1,0 +1,44 @@
+From db7b37252888a378554d69650c26ef6ad007eaa1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marco=20Trevisan=20=28Trevi=C3=B1o=29?= <mail@3v1n0.net>
+Date: Thu, 3 Oct 2024 12:21:53 +0200
+Subject: [PATCH] stylesheet: Add wartybrown accent color
+
+The Ubuntu 20th anniversary color has to be supported!
+
+This patch is only needed until 22.10 EOL.
+
+diff --git a/src/stylesheet/meson.build b/src/stylesheet/meson.build
+index a77302f6..dc08bc43 100644
+--- a/src/stylesheet/meson.build
++++ b/src/stylesheet/meson.build
+@@ -16,6 +16,7 @@ if get_option('yaru-accent-colors')
+       'purple',
+       'magenta',
+       'red',
++      'wartybrown',
+       'yellow',
+   ]
+ 
+diff --git a/src/stylesheet/yaru_accent_colors.scss b/src/stylesheet/yaru_accent_colors.scss
+index d3ea98e1..a570f5b8 100644
+--- a/src/stylesheet/yaru_accent_colors.scss
++++ b/src/stylesheet/yaru_accent_colors.scss
+@@ -23,6 +23,8 @@
+         $color: #B34CB3;
+     } @else if $accent_color == 'red' {
+         $color: #DA3450;
++    } @else if $accent_color == 'wartybrown' {
++        $color: #B39169;
+     } @else if $accent_color == 'yellow' {
+         $color: #C88800;
+     } @else {
+@@ -49,6 +51,9 @@ $accent_color: $yaru_accent_bg_color;
+ @if str-contains('@yaru_theme_entry_point@', 'stylesheet/defaults') {
+     $window-bg-color: if($variant == 'light', #FAFAFA, lighten($jet, 8%));
+     $window-fg-color: if($variant == 'light', $inkstone, $porcelain);
++    @if @yaru_accent_color@ == 'wartybrown' and $variant == 'light' {
++        $window-bg-color: #eeeeee;
++    }
+     @define-color window_bg_color #{$window-bg-color};
+     @define-color window_fg_color #{$window-fg-color};
+ 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -727,6 +727,7 @@ parts:
     override-pull: |
       craftctl default
       patch -p1 < $CRAFT_PROJECT_DIR/patches/style-manager-Support-Yaru-accent-colors.patch
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/stylesheet-Add-wartybrown-accent-color.patch
 
   libportal:
     after: [gtk3, gtk4, gtk-locales, meson-deps ]


### PR DESCRIPTION
The Ubuntu 20th anniversary color has to be supported!

This patch is only needed until 22.10 EOL.

---

This patch was done long time ago, but apparently not subitted?!