### PR TITLE
[gnome-42] Compute version adding the sdk version as base

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gnome-42-2204
-version: git
+adopt-info: gnome-sdk
 summary: Shared GNOME 42 Ubuntu stack
 source-code: https://github.com/ubuntu/gnome-sdk/tree/gnome-42-2204
 description: |
@@ -36,6 +36,19 @@ parts:
   gnome-sdk:
     plugin: nil
     stage-snaps: [ gnome-42-2204-sdk/latest/stable ]
+    override-build: |
+      set -eu
+      craftctl default
+      sdk_version=$(sed -n  's/^version:\s*\(.*\)/\1/p' \
+        ${CRAFT_PART_INSTALL}/snap.gnome-42-2204-sdk/manifest.yaml)
+
+      # Use the same logic of snapcraft
+      project_version=$(git -C "${CRAFT_PROJECT_DIR}" describe --dirty 2>/dev/null || true)
+      if [ -z "${project_version}" ]; then
+        project_version="0+git.$(git -C "${CRAFT_PROJECT_DIR}" describe --dirty --always)"
+      fi
+      version="${project_version}-sdk${sdk_version}"
+      craftctl set version="${version:0:32}"
     stage:
       - lib/*/bindtextdomain.so
       - usr


### PR DESCRIPTION
The same snap extension can be built against different SDKs, so make it clearer in the revision