### PR TITLE
Fix strip-binaries.py

### DIFF
--- a/tools/strip_binaries.py
+++ b/tools/strip_binaries.py
@@ -41,6 +41,8 @@ def read_elf_type(filepath):
                 for note in sect.iter_notes():
                     if  note['n_type'] == 'NT_GNU_BUILD_ID':
                         buildId = note['n_desc']
+                        if isinstance(buildId, bytes):
+                            buildId = buildId.hex()
                         break
         except:
             return None, None


### PR DESCRIPTION
In some libraries, the ELF module returns something that isn't a text string, but instead a bytes array, and trying to build a path with that breaks the execution.

This patch fixes this by translating the bytes into an hexadecimal string, as expected.