### PR TITLE
Fix cargo-c build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -385,7 +385,7 @@ parts:
       curl https://sh.rustup.rs -sSf > cargo.sh
       sh ./cargo.sh -y
       export PATH=$PATH:$HOME/.cargo/bin
-      ~/.cargo/bin/cargo install cargo-c
+      ~/.cargo/bin/cargo install cargo-c --locked
       cp ~/.cargo/bin/* /usr/local/bin
     override-stage: |
       craftctl default


### PR DESCRIPTION
Cargo dependencies seem to be weaker than required,and a recent change breaks building. This patch fixes it.

More info: https://github.com/lu-zero/cargo-c/pull/453