### PR TITLE
Fix dependencies for gobject-introspection and Vapigen

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -34,9 +34,9 @@ jobs:
           tools/check_dependencies.py test_data/test3.yaml
       - name: Invert success and failure for tests
         run: |
-          if [[ ${{ steps.checker-test1.outcome }} != "failure" ]]; then exit 1; fi
-          if [[ ${{ steps.checker-test2.outcome }} != "failure" ]]; then exit 1; fi
-          if [[ ${{ steps.checker-test3.outcome }} != "failure" ]]; then exit 1; fi
+          if [ "${{ steps.checker-test1.outcome }}" != "failure" ]; then exit 1; fi
+          if [ "${{ steps.checker-test2.outcome }}" != "failure" ]; then exit 1; fi
+          if [ "${{ steps.checker-test3.outcome }}" != "failure" ]; then exit 1; fi
       - name: Verify dependencies
         run: |
           tools/check_dependencies.py

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -18,23 +18,25 @@ jobs:
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-yaml
       - name: Verity dependency checker test1
+        id: checker-test1
         continue-on-error: true
         run: |
           tools/check_dependencies.py test_data/test1.yaml
-      - name: Invert success and failure for test1
-        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Verity dependency checker test2
+        id: checker-test2
         continue-on-error: true
         run: |
           tools/check_dependencies.py test_data/test2.yaml
-      - name: Invert success and failure for test1
-        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Verity dependency checker test3
+        id: checker-test3
         continue-on-error: true
         run: |
           tools/check_dependencies.py test_data/test3.yaml
-      - name: Invert success and failure for test1
-        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
+      - name: Invert success and failure for tests
+        run: |
+          if [[ ${{ steps.checker-test1.outcome }} != "failure" ]]; then exit 1; fi
+          if [[ ${{ steps.checker-test2.outcome }} != "failure" ]]; then exit 1; fi
+          if [[ ${{ steps.checker-test3.outcome }} != "failure" ]]; then exit 1; fi
       - name: Verify dependencies
         run: |
           tools/check_dependencies.py

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -17,6 +17,24 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-yaml
+      - name: Verity dependency checker test1
+        continue-on-error: true
+        run: |
+          tools/check_dependencies.py test_data/test1.yaml
+      - name: Invert success and failure for test1
+        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
+      - name: Verity dependency checker test2
+        continue-on-error: true
+        run: |
+          tools/check_dependencies.py test_data/test2.yaml
+      - name: Invert success and failure for test1
+        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
+      - name: Verity dependency checker test3
+        continue-on-error: true
+        run: |
+          tools/check_dependencies.py test_data/test3.yaml
+      - name: Invert success and failure for test1
+        run: if [[ ${{ steps.lint-incorrect.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Verify dependencies
         run: |
           tools/check_dependencies.py

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,7 @@ parts:
                           $CRAFT_STAGE/usr/share/pkgconfig\
                           ${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
       - CRAFT_EXT_CORE_LEVEL: core24
+      - PATH: $CRAFT_STAGE/usr/bin:$PATH
 
   ninja:
     plugin: nil
@@ -194,7 +195,6 @@ parts:
   gobject-introspection:
     after: [ cairo, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/gobject-introspection.git
-    # using 1.82.0 breaks libportal
     source-tag: '1.80.1'
 # ext:updatesnap
 #   version-format:
@@ -269,7 +269,7 @@ parts:
     build-environment: *buildenv
 
   harfbuzz:
-    after: [ fribidi, meson-deps ]
+    after: [ fribidi, meson-deps, gobject-introspection ]
     source: https://github.com/harfbuzz/harfbuzz.git
     source-tag: '10.4.0' # developers declared that they won't break ABI
     source-depth: 1
@@ -302,7 +302,7 @@ parts:
       - libgraphite2-dev
 
   pango:
-    after: [ libffi, harfbuzz, meson-deps ]
+    after: [ libffi, harfbuzz, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/pango.git
     source-tag: '1.56.3'
     source-depth: 1
@@ -324,7 +324,7 @@ parts:
       - cmake
 
   gdk-pixbuf:
-    after: [ pango, meson-deps ]
+    after: [ pango, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gdk-pixbuf.git
     source-tag: '2.42.12'
     source-depth: 1
@@ -357,7 +357,7 @@ parts:
       - libtiff-dev
 
   librsvg:
-    after: [ gdk-pixbuf, vala, meson-deps ]
+    after: [ gdk-pixbuf, vala, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librsvg.git
     source-tag: '2.60.0' # they left the odd->unstable even->stable scheme, and now all tags are stable
 # ext:updatesnap
@@ -409,7 +409,7 @@ parts:
       - xutils-dev
 
   json-glib:
-    after: [ epoxy, meson-deps ]
+    after: [ epoxy, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/json-glib.git
     source-tag: '1.10.6'
     source-depth: 1
@@ -446,7 +446,7 @@ parts:
       sed -i 's#^\#!/usr/bin/env python$#\#!/usr/bin/env python3#g' src/psl-make-dafsa
 
   libsoup3:
-    after: [ libpsl, meson-deps ]
+    after: [ libpsl, meson-deps, vala, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libsoup.git
     source-tag: '3.6.4'
     source-depth: 1
@@ -468,7 +468,7 @@ parts:
       - libnghttp2-dev
 
   librest:
-    after: [ libsoup3, meson-deps ]
+    after: [ libsoup3, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librest.git
     source-tag: '1.0.0'
     source-depth: 1
@@ -502,7 +502,7 @@ parts:
     build-environment: *buildenv
 
   gtk3:
-    after: [ wayland-protocols, harfbuzz, pango, meson-deps ]
+    after: [ wayland-protocols, harfbuzz, pango, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
     source-tag: '3.24.49'
 # ext:updatesnap
@@ -549,7 +549,7 @@ parts:
       patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
 
   gtk4:
-    after: [ wayland-protocols, harfbuzz, pango, meson-deps ]
+    after: [ wayland-protocols, harfbuzz, pango, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
     source-tag: '4.18.3'
 # ext:updatesnap
@@ -619,7 +619,7 @@ parts:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
     source-tag: '1.6.2'
     source-depth: 1
-    after: [ meson-deps, gtk4 ]
+    after: [ meson-deps, gtk4, vala, gobject-introspection ]
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -648,7 +648,7 @@ parts:
       patch -p1 < $CRAFT_PROJECT_DIR/patches/style-Add-wartybrown-accent-support.patch
 
   libportal:
-    after: [gtk3, gtk4, gtk-locales, meson-deps ]
+    after: [gtk3, gtk4, gtk-locales, vala, meson-deps, gobject-introspection ]
     plugin: meson
     source: https://github.com/flatpak/libportal.git
     source-tag: '0.9.1'
@@ -820,7 +820,7 @@ parts:
       craftctl default
 
   gtksourceview:
-    after: [ gtkmm, meson-deps ]
+    after: [ gtkmm, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gtksourceview.git
     source-tag: '5.16.0'
 # ext:updatesnap
@@ -941,7 +941,7 @@ parts:
       - yelp-tools
 
   cogl:
-    after: [ gnome-desktop ]
+    after: [ gnome-desktop, gobject-introspection ]
     source: https://gitlab.gnome.org/Archive/cogl.git
     source-tag: '1.22.8'
     source-depth: 1
@@ -1095,7 +1095,7 @@ parts:
     build-environment: *buildenv
 
   libpeas:
-    after: [ clutter-gtk, meson-deps ]
+    after: [ clutter-gtk, meson-deps, vala, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libpeas.git
     source-tag: 'libpeas-1.36.0' # developers say that they don't want to break ABI, so it should be safe to always update
 # ext:updatesnap
@@ -1146,7 +1146,7 @@ parts:
     build-environment: *buildenv
 
   libhandy:
-    after: [ pygobject, meson-deps ]
+    after: [ pygobject, meson-deps, vala, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libhandy.git
     source-tag: '1.8.3'
     source-depth: 1
@@ -1324,7 +1324,7 @@ parts:
       done
 
   libayatana-appindicator:
-    after: [libayatana-ido, glib, gtk3]
+    after: [libayatana-ido, glib, gtk3, vala]
     source: https://github.com/AyatanaIndicators/libayatana-appindicator.git
     source-tag: '0.5.94'
     source-depth: 1

--- a/test_data/test1.yaml
+++ b/test_data/test1.yaml
@@ -446,7 +446,7 @@ parts:
       sed -i 's#^\#!/usr/bin/env python$#\#!/usr/bin/env python3#g' src/psl-make-dafsa
 
   libsoup3:
-    after: [ libpsl, meson-deps, vala, gobject-introspection ]
+    after: [ libpsl, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/libsoup.git
     source-tag: '3.6.4'
     source-depth: 1

--- a/test_data/test2.yaml
+++ b/test_data/test2.yaml
@@ -357,7 +357,7 @@ parts:
       - libtiff-dev
 
   librsvg:
-    after: [ gdk-pixbuf, vala, meson-deps, gobject-introspection ]
+    after: [ gdk-pixbuf, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librsvg.git
     source-tag: '2.60.0' # they left the odd->unstable even->stable scheme, and now all tags are stable
 # ext:updatesnap

--- a/test_data/test3.yaml
+++ b/test_data/test3.yaml
@@ -234,7 +234,7 @@ parts:
       - libgraphviz-dev
 
   at-spi2-core:
-    after: [ glib, gobject-introspection, meson-deps ]
+    after: [ glib, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/at-spi2-core.git
     source-tag: 'AT_SPI2_CORE_2_52_0'
 # ext:updatesnap

--- a/tools/check_dependencies.py
+++ b/tools/check_dependencies.py
@@ -8,6 +8,9 @@ config_file = "snapcraft.yaml"
 if not os.path.exists(config_file):
     config_file = os.path.join("snap", "snapcraft.yaml")
 
+if len(sys.argv) > 1:
+    config_file = sys.argv[1]
+
 data = yaml.safe_load(open(config_file, "r"))
 
 ########################################################
@@ -50,30 +53,28 @@ for dependency in deb_dependencies:
         print(f"DEBS part must be after {dependency}")
         failed = True
 
-def check_dependency(*, part_name, part, string_to_find, dependency):
+def check_dependency(*, part_name, part, strings_to_find, dependency):
     if "meson-parameters" not in part:
         return False
     for meson_parameter in part["meson-parameters"]:
-        if meson_parameter.find(string_to_find) == -1:
-            continue
-        if dependency not in part["after"]:
-            print(f"Part {part_name} requires {dependency} dependency due to meson option {meson_parameter}")
-            return True
+        for string_to_find in strings_to_find:
+            if (meson_parameter.find(string_to_find) != -1) and (dependency not in part["after"]):
+                print(f"Part {part_name} requires {dependency} dependency due to meson option {meson_parameter}")
+                return True
     return False
-
 
 ###################################################
 # Ensure that any part that builds introspection, #
 # depends on gobject-introspection.               #
 ###################################################
 
-goi_exceptions = ["glib"]
+goi_exceptions = ["glib"] # parts that must NOT have gobject-introspection as dependency, even if detected automatically
 for part_name in data["parts"]:
     if part_name in goi_exceptions:
         continue
     if check_dependency(part_name=part_name,
                         part = data["parts"][part_name],
-                        string_to_find="introspection",
+                        strings_to_find=["introspection"],
                         dependency="gobject-introspection"):
         failed = True
 
@@ -82,13 +83,13 @@ for part_name in data["parts"]:
 # depends on vala.                            #
 ###############################################
 
-vapi_exceptions = []
+vapi_exceptions = ['vala'] # parts that must NOT have vala as dependency, even if detected automatically
 for part_name in data["parts"]:
     if part_name in vapi_exceptions:
         continue
     if check_dependency(part_name=part_name,
                         part = data["parts"][part_name],
-                        string_to_find="vapi",
+                        strings_to_find=['vala', 'vapi'],
                         dependency="vala"):
         failed = True
 

--- a/tools/check_dependencies.py
+++ b/tools/check_dependencies.py
@@ -4,15 +4,17 @@ import os
 import sys
 import yaml
 
-# Ensure that "deb" part depends on all previous parts
-
 config_file = "snapcraft.yaml"
 if not os.path.exists(config_file):
     config_file = os.path.join("snap", "snapcraft.yaml")
 
 data = yaml.safe_load(open(config_file, "r"))
 
-exceptions = ['buildenv']
+########################################################
+# Ensure that "deb" part depends on all previous parts #
+########################################################
+
+deb_exceptions = ['buildenv']
 
 def filldeps(part):
     """ Fill recursively the dependencies of each part """
@@ -38,7 +40,7 @@ for part in data["parts"]:
     if "debs" in dependencies[part]:
         # if it depends on debs, it must be after, so don't take it into account
         continue
-    if part in exceptions:
+    if part in deb_exceptions:
         continue
     deb_dependencies.append(part)
 
@@ -46,6 +48,48 @@ failed = False
 for dependency in deb_dependencies:
     if dependency not in dependencies["debs"]:
         print(f"DEBS part must be after {dependency}")
+        failed = True
+
+def check_dependency(*, part_name, part, string_to_find, dependency):
+    if "meson-parameters" not in part:
+        return False
+    for meson_parameter in part["meson-parameters"]:
+        if meson_parameter.find(string_to_find) == -1:
+            continue
+        if dependency not in part["after"]:
+            print(f"Part {part_name} requires {dependency} dependency due to meson option {meson_parameter}")
+            return True
+    return False
+
+
+###################################################
+# Ensure that any part that builds introspection, #
+# depends on gobject-introspection.               #
+###################################################
+
+goi_exceptions = ["glib"]
+for part_name in data["parts"]:
+    if part_name in goi_exceptions:
+        continue
+    if check_dependency(part_name=part_name,
+                        part = data["parts"][part_name],
+                        string_to_find="introspection",
+                        dependency="gobject-introspection"):
+        failed = True
+
+###############################################
+# Ensure that any part that builds VAPI info, #
+# depends on vala.                            #
+###############################################
+
+vapi_exceptions = []
+for part_name in data["parts"]:
+    if part_name in vapi_exceptions:
+        continue
+    if check_dependency(part_name=part_name,
+                        part = data["parts"][part_name],
+                        string_to_find="vapi",
+                        dependency="vala"):
         failed = True
 
 if failed:


### PR DESCRIPTION
Some parts use gobject-introspection or vapigen, which require Vala and Gobject-introspection parts being built before. Unfortunately, some dependencies didn't account for this.

Also, the PATH environment was wrong, and didn't prioritize the STAGE, so in some cases the wrong binary was being used.

Due to all of this, building libportal failed when using gobject-introspection greater than 1.82.0.

This PR fixes all these things, and also adds an extra check in check_dependencies.py to ensure that any part that is building gobject-introspection or vapi files have the correct dependencies in the `after` entry. For this to work better, I also added missing meson options that builds gobject-introspection and vapi files (those options where already set to true by default, so they change nothing relative to the output snap; only ensures that dependencies will be correct).