### PR TITLE
SDK: Fix so libraries dangling symlinks

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1606,10 +1606,6 @@ parts:
       cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       find . -type f,l -exec rm -fv $CRAFT_PART_INSTALL/usr/lib/{} \;
       find . -type f,l -name "*.so.*" -exec sh -c "rm -fv $CRAFT_PART_INSTALL/usr/lib/{}*" \;
-      # FIXME, need to figure out why libayatana-appindicator install those
-      rm -f $CRAFT_PART_INSTALL/usr/lib/*/libatk-1.0.so*
-      rm -f $CRAFT_PART_INSTALL/usr/lib/*/libatk-bridge-2.0.so*
-      rm -f $CRAFT_PART_INSTALL/usr/lib/*/libatspi.so*
     stage:
       - -usr/bin/fc-cache
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1748,11 +1748,6 @@ parts:
       rm -rf usr/share/locale-langpack/kab
       rm -f usr/share/unity/client-scopes.json
 
-      # Libm is a dangling symlink in armhf and riscv64, breaking builds.
-      # We don't need them anyway, the base image has them.
-      rm -f usr/lib/*/lib[mc].so || :
-      rm -f usr/lib/*/lib[mc].a  || :
-
       find . -type d -empty -delete
 
       PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1456,10 +1456,12 @@ parts:
       - libdrm2
       - libdrm-dev
       - libegl1-mesa-dev
+      - libelf1t64
       - libevdev2
       - libevdev-dev
       - libexpat1
       - libexpat1-dev
+      - libffi8
       - libfontconfig1-dev
       - libfreetype6
       - libfreetype-dev
@@ -1481,6 +1483,7 @@ parts:
       - libgraphene-1.0-dev
       - libgraphviz-dev
       - libgspell-1-dev
+      - libgssapi-krb5-2
       - libgstreamer-plugins-bad1.0-dev
       - libgstreamer-plugins-base1.0-dev
       - libgstreamer-plugins-good1.0-dev
@@ -1491,6 +1494,8 @@ parts:
       - libidn2-0
       - libidn2-dev
       - libjpeg-dev
+      - libk5crypto3
+      - libkrb5support0
       - libkrb5-3
       - libkrb5-dev
       - liblcms2-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1701,7 +1701,7 @@ parts:
       if [ ${#invalid_links[@]} -gt 0 ]; then
         echo "Invalid symlinks found:"
         echo "${invalid_links[@]}"
-        echo "Ensure full package set is staged!"
+        echo "Ensure full package set (runtime and dev files) is staged!"
         exit 1;
       fi
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1682,10 +1682,27 @@ parts:
       ln -s gettext-0.19.8 usr/share/gettext-current
       ln -s gdk-pixbuf-2.0/2.10.0 usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-current
 
-      # Fix dangling symlink by overwriting it
-      ln -sf lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0 usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so
-      # CHECK THIS When changing the core base, this line must be update
-      cp /snap/$CRAFT_EXT_CORE_LEVEL/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0 lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
+      # Check dangling libraries symlinks
+      invalid_links=()
+      core_root_prefix=/snap/$CRAFT_EXT_CORE_LEVEL/current
+      for i in $(find "$CRAFT_PRIME"/{usr/,}lib -xtype l -name '*.so'); do
+        # Try fix dangling symlink by overwriting it with core library if any.
+        rel_lib_path=$(realpath --relative-to="$CRAFT_PRIME" "$i")
+        core_lib=$core_root_prefix/$(dirname "$rel_lib_path")/$(readlink "$i")
+
+        if realpath --canonicalize-existing "$core_lib"; then
+          ln -svf "${core_lib#"$core_root_prefix"}" "$i"
+          continue
+        fi
+
+        echo "$i: dangling symlink!"
+        invalid_links+=($i)
+      done
+      if [ ${#invalid_links[@]} -gt 0 ]; then
+        echo "Invalid symlinks found:"
+        echo "${invalid_links[@]}"
+        exit 1;
+      fi
 
       # Necessary for armhf builds, triggers review warning
       if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" = "arm-linux-gnueabihf" ]; then

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1443,6 +1443,8 @@ parts:
       - libbrotli-dev
       - libbz2-1.0
       - libbz2-dev
+      - libc6
+      - libc6-dev
       - libcairo2-dev
       - libcanberra-gtk3-dev
       - libcanberra-pulse
@@ -1506,6 +1508,8 @@ parts:
       - libnsl-dev
       - libnss3-dev
       - libopenjp2-7-dev
+      - libpciaccess0
+      - libpciaccess-dev
       - libpcre2-8-0
       - libpcre2-dev
       - libpcre3

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1592,15 +1592,18 @@ parts:
     override-build: |
       set -eux
       craftctl default
+
+      # Drop all the duplicates *.so.* library files that have been pulled from
+      # deb files and that we're already shipping as part of source-compiled parts
       cd $CRAFT_STAGE/usr
-      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/{} \;
-      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/{}*" \;
+      find . -type f,l -exec rm -fv $CRAFT_PART_INSTALL/usr/{} \;
+      find . -type f,l -name "*.so.*" -exec sh -c "rm -fv $CRAFT_PART_INSTALL/usr/{}*" \;
       cd $CRAFT_STAGE/usr/lib
-      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{} \;
-      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{}*" \;
+      find . -type f,l -exec rm -fv $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{} \;
+      find . -type f,l -name "*.so.*" -exec sh -c "rm -fv $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{}*" \;
       cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
-      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/{} \;
-      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/{}*" \;
+      find . -type f,l -exec rm -fv $CRAFT_PART_INSTALL/usr/lib/{} \;
+      find . -type f,l -name "*.so.*" -exec sh -c "rm -fv $CRAFT_PART_INSTALL/usr/lib/{}*" \;
       # FIXME, need to figure out why libayatana-appindicator install those
       rm -f $CRAFT_PART_INSTALL/usr/lib/*/libatk-1.0.so*
       rm -f $CRAFT_PART_INSTALL/usr/lib/*/libatk-bridge-2.0.so*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1691,21 +1691,13 @@ parts:
       invalid_links=()
       core_root_prefix=/snap/$CRAFT_EXT_CORE_LEVEL/current
       for i in $(find "$CRAFT_PRIME"/{usr/,}lib -xtype l -name '*.so'); do
-        # Try fix dangling symlink by overwriting it with core library if any.
-        rel_lib_path=$(realpath --relative-to="$CRAFT_PRIME" "$i")
-        core_lib=$core_root_prefix/$(dirname "$rel_lib_path")/$(readlink "$i")
-
-        if realpath --canonicalize-existing "$core_lib"; then
-          ln -svf "${core_lib#"$core_root_prefix"}" "$i"
-          continue
-        fi
-
         echo "$i: dangling symlink!"
         invalid_links+=($i)
       done
       if [ ${#invalid_links[@]} -gt 0 ]; then
         echo "Invalid symlinks found:"
         echo "${invalid_links[@]}"
+        echo "Ensure full package set is staged!"
         exit 1;
       fi
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1448,7 +1448,9 @@ parts:
       - libcairo2-dev
       - libcanberra-gtk3-dev
       - libcanberra-pulse
+      - libcrypt1
       - libcrypt-dev
+      - libcom-err2
       - libcurl4-openssl-dev
       - libdbus-1-3
       - libdbus-1-dev
@@ -1546,6 +1548,7 @@ parts:
       - libtasn1-6-dev
       - libtdb-dev
       - libthai-dev
+      - libtirpc3t64
       - libudev1
       - libudev-dev
       - libunity-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -90,8 +90,6 @@ parts:
     override-stage: |
       set -eux
       craftctl default
-      rm $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lib[mc].a || :
-      rm $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lib[mc].so || :
       LIBTOOLIZE=usr/bin/libtoolize
       sed -i 's#pkgauxdir="#pkgauxdir="$CRAFT_STAGE#' $LIBTOOLIZE
       sed -i 's#pkgltdldir="#pkgltdldir="$CRAFT_STAGE#' $LIBTOOLIZE


### PR DESCRIPTION
libraries .so files provided by -dev packages normally point to the
versioned so file, but if these files are provided by the core snap or
another base snap then we should instead use them, if they're not
provided by the SDK itself.

So, ensure that all the symlinks in the lib directory are actually
pointing to a library file, trying to resolve them with the
core-provided libraries as first try.

This fixes the compile issue we have with gnome-boxes as per the linking issues:

```
2025-04-21 20:49:32.887 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libpciaccess.a(linux_sysfs.o): warning: relocation against `stderr@@GLIBC_2.2.5' in read-only section `.text'
2025-04-21 20:49:32.887 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libpciaccess.a(common_device_name.o): in function `populate_vendor':
2025-04-21 20:49:32.887 :: (.text+0x18d): undefined reference to `gzopen'
2025-04-21 20:49:32.887 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: (.text+0x1bc): undefined reference to `gzgets'
2025-04-21 20:49:32.887 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: (.text+0x394): undefined reference to `gzclose'
2025-04-21 20:49:32.888 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: (.text+0x420): undefined reference to `gzopen'
2025-04-21 20:49:32.888 :: /snap/gnome-46-2404-sdk/current/usr/bin/ld: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libpciaccess.a(linux_sysfs.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
```

This fixes also these other cases:

```
2025-04-21T19:14:27.7652675Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libBrokenLocale.so
2025-04-21T19:14:27.7655234Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1
2025-04-21T19:14:27.7657027Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1
2025-04-21T19:14:27.7668303Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1
2025-04-21T19:14:27.7670954Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1 /root/prime/usr/lib/x86_64-linux-gnu/libBrokenLocale.so
2025-04-21T19:14:27.7682861Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libBrokenLocale.so' -> '/usr/lib/x86_64-linux-gnu/libBrokenLocale.so.1'
2025-04-21T19:14:27.7685855Z :: + 
2025-04-21T19:14:27.8632229Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libanl.so
2025-04-21T19:14:27.8645632Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libanl.so.1
2025-04-21T19:14:27.8648639Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libanl.so.1
2025-04-21T19:14:27.8658523Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libanl.so.1
2025-04-21T19:14:27.8676057Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libanl.so.1 /root/prime/usr/lib/x86_64-linux-gnu/libanl.so
2025-04-21T19:14:27.8676810Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libanl.so' -> '/usr/lib/x86_64-linux-gnu/libanl.so.1'
2025-04-21T19:14:27.8679512Z :: + 
2025-04-21T19:14:27.9091535Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so
2025-04-21T19:14:27.9097459Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0
2025-04-21T19:14:27.9098504Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0
2025-04-21T19:14:27.9107874Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0
2025-04-21T19:14:27.9111709Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0 /root/prime/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so
2025-04-21T19:14:27.9126662Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so' -> '/usr/lib/x86_64-linux-gnu/libc_malloc_debug.so.0'
2025-04-21T19:14:27.9128331Z :: + 
2025-04-21T19:14:27.9381751Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libcrypt.so
2025-04-21T19:14:27.9405472Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2025-04-21T19:14:27.9406127Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2025-04-21T19:14:27.9407716Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2025-04-21T19:14:27.9413478Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0 /root/prime/usr/lib/x86_64-linux-gnu/libcrypt.so
2025-04-21T19:14:27.9427626Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libcrypt.so' -> '/usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0'
2025-04-21T19:14:27.9428341Z :: + 
2025-04-21T19:14:28.2410903Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libmvec.so
2025-04-21T19:14:28.2424731Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libmvec.so.1
2025-04-21T19:14:28.2425665Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libmvec.so.1
2025-04-21T19:14:28.2433988Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libmvec.so.1
2025-04-21T19:14:28.2437987Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libmvec.so.1 /root/prime/usr/lib/x86_64-linux-gnu/libmvec.so
2025-04-21T19:14:28.2448685Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libmvec.so' -> '/usr/lib/x86_64-linux-gnu/libmvec.so.1'
2025-04-21T19:14:28.2451476Z :: + 
2025-04-21T19:14:28.2571158Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libnss_compat.so
2025-04-21T19:14:28.2575968Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libnss_compat.so.2
2025-04-21T19:14:28.2576937Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libnss_compat.so.2
2025-04-21T19:14:28.2590023Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libnss_compat.so.2
2025-04-21T19:14:28.2591451Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libnss_compat.so.2 /root/prime/usr/lib/x86_64-linux-gnu/libnss_compat.so
2025-04-21T19:14:28.2603414Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libnss_compat.so' -> '/usr/lib/x86_64-linux-gnu/libnss_compat.so.2'
2025-04-21T19:14:28.2617420Z :: + 
2025-04-21T19:14:28.2633341Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libnss_hesiod.so
2025-04-21T19:14:28.2638364Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2
2025-04-21T19:14:28.2647972Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2
2025-04-21T19:14:28.2651783Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2
2025-04-21T19:14:28.2654605Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2 /root/prime/usr/lib/x86_64-linux-gnu/libnss_hesiod.so
2025-04-21T19:14:28.2672222Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libnss_hesiod.so' -> '/usr/lib/x86_64-linux-gnu/libnss_hesiod.so.2'
2025-04-21T19:14:28.2674379Z :: + 
2025-04-21T19:14:28.2958314Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libpciaccess.so
2025-04-21T19:14:28.2972622Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1
2025-04-21T19:14:28.2973906Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1
2025-04-21T19:14:28.2983570Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1
2025-04-21T19:14:28.2990439Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1 /root/prime/usr/lib/x86_64-linux-gnu/libpciaccess.so
2025-04-21T19:14:28.3002763Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libpciaccess.so' -> '/usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1'
2025-04-21T19:14:28.3006533Z :: + 
2025-04-21T19:14:28.3782845Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libresolv.so
2025-04-21T19:14:28.3797871Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libresolv.so.2
2025-04-21T19:14:28.3799269Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libresolv.so.2
2025-04-21T19:14:28.3808636Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libresolv.so.2
2025-04-21T19:14:28.3822038Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libresolv.so.2 /root/prime/usr/lib/x86_64-linux-gnu/libresolv.so
2025-04-21T19:14:28.3826156Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libresolv.so' -> '/usr/lib/x86_64-linux-gnu/libresolv.so.2'
2025-04-21T19:14:28.3827052Z :: + 
2025-04-21T19:14:28.4324023Z :: ++ readlink /root/prime/usr/lib/x86_64-linux-gnu/libthread_db.so
2025-04-21T19:14:28.4338047Z :: + core_lib=/snap/core24/current/usr/lib/x86_64-linux-gnu/libthread_db.so.1
2025-04-21T19:14:28.4339762Z :: + realpath --canonicalize-existing /snap/core24/current/usr/lib/x86_64-linux-gnu/libthread_db.so.1
2025-04-21T19:14:28.4351158Z :: /snap/core24/888/usr/lib/x86_64-linux-gnu/libthread_db.so.1
2025-04-21T19:14:28.4355710Z :: + ln -svf /usr/lib/x86_64-linux-gnu/libthread_db.so.1 /root/prime/usr/lib/x86_64-linux-gnu/libthread_db.so
2025-04-21T19:14:28.4368474Z :: '/root/prime/usr/lib/x86_64-linux-gnu/libthread_db.so' -> '/usr/lib/x86_64-linux-gnu/libthread_db.so.1'
2025-04-21T19:14:28.4381415Z :: + 
```

UDENG-6680