### PR TITLE
Fix librest version tag

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -472,7 +472,7 @@ parts:
   librest:
     after: [ libsoup3, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librest.git
-    source-tag: '1.0.0'
+    source-tag: '0.9.1'
     source-depth: 1
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
For some reason, the 1.0.0 tag in librest have disappeared, and the current one is 0.9.1.

This PR fixes this, allowing again to build the SDK.