### PR TITLE
Remove invalid pkgconfig files and broken links

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1666,6 +1666,16 @@ parts:
       rm -f usr/lib/*.la
       rm -f usr/lib/*/*.la
 
+      # cleanup broken links; all these are from libc6-dev, libcrypt-dev and libpciaccess-dev
+      for FILE in libcrypt pciaccess libBrokenLocale libanl libc_malloc_debug libmvec libnss_compat libnss_hesiod libpciaccess libresolv libthread_db; do
+        rm -f usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${FILE}.so
+        rm -f usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${FILE}.a
+      done
+
+      # remove invalid pkgconfig files from libcrypt-dev and libpciaccess-dev (there are no pkgconfig files in libc6-dev)
+      rm -f usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcrypt.pc
+      rm -f usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pciaccess.pc
+
       # Cleanup from libunity addition
       rm -f usr/bin/dbus-binding-tool
       rm -f usr/bin/unity-scope-loader

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1666,7 +1666,8 @@ parts:
       rm -f usr/lib/*.la
       rm -f usr/lib/*/*.la
 
-      # cleanup broken links; all these are from libc6-dev, libcrypt-dev and libpciaccess-dev
+      # Cleanup broken links and static link files.
+      # All these are from libc6-dev, libcrypt-dev and libpciaccess-dev
       for FILE in libcrypt pciaccess libBrokenLocale libanl libc_malloc_debug libmvec libnss_compat libnss_hesiod libpciaccess libresolv libthread_db; do
         rm -f usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${FILE}.so
         rm -f usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${FILE}.a


### PR DESCRIPTION
Some soft links to libraries that are already in Core 24, and thus, don't needed, are kept in the SDK.

Also, two pkgconfig files are also kept, pointing to the SDK library folder. But since those two libraries (libcrypt and libpciaccess) are already in Core24, and the libraries themselves are deleted, this breaks any build that tries to use any of those.

Removing the broken soft links and the pkgconfig files fixes this. With this patch, installing the development .deb packages using the "build-packages" statement in the snapcraft.yaml ensures that the requires build files are available and that no other pkgconfig file will override the correct ones.