### PR TITLE
glib: Bump to 2.84.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -117,7 +117,7 @@ parts:
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.84.0'
+    source-tag: '2.84.2'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true


### PR DESCRIPTION
It's the newer stable version, and 2.84.1 fixes various relevant issues