### PR TITLE
Use upstream libffi

### DIFF
--- a/patches/libffi-autoconf.patch
+++ b/patches/libffi-autoconf.patch
@@ -1,0 +1,23 @@
+diff --git a/configure.ac b/configure.ac
+index 69ed043..d811071 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,6 +1,6 @@
+ dnl Process this with autoconf to create configure
+ 
+-AC_PREREQ([2.72])
++AC_PREREQ([2.68])
+ 
+ AC_INIT([libffi],[3.5.0],[http://github.com/libffi/libffi/issues])
+ AC_CONFIG_HEADERS([fficonfig.h])
+@@ -94,10 +94,6 @@ m4_warn([obsolete],
+ [The preprocessor macro `STDC_HEADERS' is obsolete.
+   Except in unusual embedded environments, you can safely include all
+   ISO C90 headers unconditionally.])dnl
+-# Autoupdate added the next two lines to ensure that your configure
+-# script's behavior did not change.  They are probably safe to remove.
+-AC_CHECK_INCLUDES_DEFAULT
+-AC_PROG_EGREP
+ 
+ AC_CHECK_FUNCS(memcpy)
+ AC_CHECK_HEADERS(alloca.h)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -104,6 +104,7 @@ parts:
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
+      - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     build-environment: *buildenv
     override-pull: |
       craftctl default

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -97,22 +97,19 @@ parts:
       sed -i 's#aclocaldir="#aclocaldir="$CRAFT_STAGE#' $LIBTOOLIZE
 
   libffi:
-    after: [ libtool, meson-deps ]
-    source: https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi.git
-    source-tag: 'meson-3.2.9999.4'
-# ext:updatesnap
-#   version-format:
-#     format: 'meson-%M.%m.%R'
+    after: [ libtool ]
+    source: https://github.com/libffi/libffi.git
+    source-tag: 'v3.5.0'
     source-depth: 1
-    plugin: meson
-    meson-parameters:
+    plugin: autotools
+    autotools-configure-parameters:
       - --prefix=/usr
-      - -Doptimization=3
-      - -Ddebug=true
     build-environment: *buildenv
     override-pull: |
       craftctl default
-      patch -p1 < $CRAFT_PROJECT_DIR/patches/libffi-enable-building-on-riscv64.patch
+      patch -p1 < $CRAFT_PROJECT_DIR/patches/libffi-autoconf.patch
+    build-packages:
+      - texinfo
 
   glib:
     after: [ libffi, meson-deps ]


### PR DESCRIPTION
Currently, libffi is being taken from a freedesktop repository, which allows to use Meson. Unfortunately, that repo isn't up to date.

This patch uses the true upstream.

Tested on:
- cheese
- chromium
- evince
- eog
- gnome-text-editor
- darktable
- zoom-client
- gnome-system-monitor
- gimp
- kicad
- gnome-clocks
- gnome-calendar
- gnome-recipes
- gnome-mahjongg