### PR TITLE
Stage g++.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1389,6 +1389,7 @@ parts:
       - appstream-util
       - desktop-file-utils
       - gcc
+      - g++
       - gettext
       - gir1.2-poppler-0.18
       - heif-gdk-pixbuf


### PR DESCRIPTION
My CMake failed:

```
::  0:01.86 DEBUG: _cxx: Looking for /snap/gnome-46-2404-sdk/current/usr/bin/g++
::  0:01.86 ERROR: Cannot find the target C++ compiler
```