### PR TITLE
Remove libm and libc

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1684,6 +1684,11 @@ parts:
       rm -rf usr/share/locale-langpack/kab
       rm -f usr/share/unity/client-scopes.json
 
+      # Libm is a dangling symlink in armhf and riscv64, breaking builds.
+      # We don't need them anyway, the base image has them.
+      rm -f usr/lib/*/lib[mc].so || :
+      rm -f usr/lib/*/lib[mc].a  || :
+
       find . -type d -empty -delete
 
       PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Causing #240 once again, failing Fifrefox in core24 in armhf and in riscv.
```
:: 1997:22.42 ld.lld: error: undefined symbol: __frexpf
:: 1997:22.44 >>> referenced by s_cbrtf.o:(__cbrtf) in archive /snap/gnome-46-2404-sdk/current/usr/lib/riscv64-linux-gnu/libm.a
:: 1997:32.99 ld.lld: error: undefined symbol: __ldexpf
:: 1997:33.00 >>> referenced by s_cbrtf.o:(__cbrtf) in archive /snap/gnome-46-2404-sdk/current/usr/lib/riscv64-linux-gnu/libm.a
:: 1997:33.01 ld.lld: error: undefined symbol: __frexp
:: 1997:33.01 >>> referenced by s_cbrt.o:(__cbrt) in archive /snap/gnome-46-2404-sdk/current/usr/lib/riscv64-linux-gnu/libm.a
:: 1997:33.02 ld.lld: error: undefined symbol: __ldexp
:: 1997:33.02 >>> referenced by s_cbrt.o:(__cbrt) in archive /snap/gnome-46-2404-sdk/current/usr/lib/riscv64-linux-gnu/libm.a
```