### PR TITLE
Update to (kind-of) last versions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
     after: [ ninja ]
     plugin: nil
     source: https://github.com/mesonbuild/meson.git
-    source-tag: '1.8.1'
+    source-tag: '1.8.4'
     source-depth: 1
     override-build: |
       python3 -m pip install --break-system-packages .
@@ -99,23 +99,20 @@ parts:
   libffi:
     after: [ libtool ]
     source: https://github.com/libffi/libffi.git
-    source-tag: 'v3.5.0'
+    source-tag: 'v3.5.2'
     source-depth: 1
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
       - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     build-environment: *buildenv
-    override-pull: |
-      craftctl default
-      patch -p1 < $CRAFT_PROJECT_DIR/patches/libffi-autoconf.patch
     build-packages:
       - texinfo
 
   glib:
     after: [ libffi, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/glib.git
-    source-tag: '2.84.2'
+    source-tag: '2.84.4'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -145,7 +142,7 @@ parts:
   pixman:
     after: [ glib, meson-deps ]
     source: https://gitlab.freedesktop.org/pixman/pixman.git
-    source-tag: 'pixman-0.46.0'
+    source-tag: 'pixman-0.46.4'
 # ext:updatesnap
 #   version-format:
 #     format: 'pixman-%M.%m.%R'
@@ -271,7 +268,7 @@ parts:
   harfbuzz:
     after: [ fribidi, meson-deps, gobject-introspection ]
     source: https://github.com/harfbuzz/harfbuzz.git
-    source-tag: '11.2.1' # developers declared that they won't break ABI
+    source-tag: '11.4.5' # developers declared that they won't break ABI
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -301,7 +298,7 @@ parts:
   pango:
     after: [ libffi, harfbuzz, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/pango.git
-    source-tag: '1.56.3'
+    source-tag: '1.56.4'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -356,7 +353,7 @@ parts:
   librsvg:
     after: [ gdk-pixbuf, vala, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librsvg.git
-    source-tag: '2.60.0' # they left the odd->unstable even->stable scheme, and now all tags are stable
+    source-tag: '2.61.1' # they left the odd->unstable even->stable scheme, and now all tags are stable
 # ext:updatesnap
 #   version-format:
 #     no-9x-revisions: true
@@ -408,7 +405,7 @@ parts:
   json-glib:
     after: [ epoxy, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/json-glib.git
-    source-tag: '1.10.6'
+    source-tag: '1.10.8'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -467,7 +464,7 @@ parts:
   librest:
     after: [ libsoup3, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/librest.git
-    source-tag: '0.9.1'
+    source-tag: '0.10.2'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -486,7 +483,7 @@ parts:
   wayland-protocols:
     after: [ meson-deps ]
     source: https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-    source-tag: '1.44'
+    source-tag: '1.45'
     source-depth: 1
     build-packages:
       - libwayland-dev
@@ -501,7 +498,7 @@ parts:
   gtk3:
     after: [ wayland-protocols, harfbuzz, pango, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '3.24.49'
+    source-tag: '3.24.50'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -548,7 +545,7 @@ parts:
   gtk4:
     after: [ wayland-protocols, harfbuzz, pango, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gtk.git
-    source-tag: '4.18.5'
+    source-tag: '4.18.6'
 # ext:updatesnap
 #   version-format:
 #     ignore-odd-minor: true
@@ -614,7 +611,7 @@ parts:
 
   libadwaita:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
-    source-tag: '1.7.4'
+    source-tag: '1.7.7'
     source-depth: 1
     after: [ meson-deps, gtk4, vala, gobject-introspection ]
     plugin: meson
@@ -667,7 +664,7 @@ parts:
   mm-common:
     after: [ libportal, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/mm-common.git
-    source-tag: '1.0.6'
+    source-tag: '1.0.7'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -920,7 +917,7 @@ parts:
   gnome-desktop:
     after: [ gsettings-desktop-schemas, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gnome-desktop.git
-    source-tag: '44.1'
+    source-tag: '44.4'
 # ext:updatesnap
 #   version-format:
 #     same-major: true
@@ -969,7 +966,7 @@ parts:
     after: [ cogl, meson-deps ]
     source: https://github.com/linuxwacom/libwacom
     source-type: git
-    source-tag: 'libwacom-2.15.0'
+    source-tag: 'libwacom-2.16.1'
 # ext:updatesnap
 #   version-format:
 #     format: 'libwacom-%M.%m.%R'
@@ -986,7 +983,7 @@ parts:
   libinput:
     after: [ libwacom, meson-deps ]
     source: https://gitlab.freedesktop.org/libinput/libinput.git
-    source-tag: '1.28.1'
+    source-tag: '1.29.1'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1136,7 +1133,7 @@ parts:
   pygobject:
     after: [ pycairo, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/pygobject.git
-    source-tag: '3.52.3'
+    source-tag: '3.54.2'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1188,7 +1185,7 @@ parts:
   p11-kit:
     after: [ gjs, meson-deps ]
     source: https://github.com/p11-glue/p11-kit.git
-    source-tag: '0.25.5'
+    source-tag: '0.25.9'
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -1223,7 +1220,7 @@ parts:
     after: [ libsecret, meson-deps ]
     source: https://gitlab.gnome.org/GNOME/libgnome-games-support.git
     source-type: git
-    source-tag: '2.0.1'
+    source-tag: '2.0.2'
     source-depth: 1
 # ext:updatesnap
 #   version-format:


### PR DESCRIPTION
Updated several libraries to more recent/latest versions.

Tested with

* cheese
* darktable
* element-desktop (fails, but seems to be a problem in the element snap)
* eog
* epiphany
* evince
* folio (fails, but it's a problem in the snap because fails with stable too. Folio edge version works)
* gimp
* gnome-characters
* gnome-mahjongg
* gnome-mines
* gnome-recipes
* gnome-system-monitor
* gnome-text-editor
* kicad
* mattermost-desktop
* shotwell
* telegram-desktop