### PR TITLE
Pull early, not in build or prime phases

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -108,6 +108,7 @@ parts:
     build-environment: *buildenv
     build-packages:
       - texinfo
+      - libltdl-dev
 
   glib:
     after: [ libffi, meson-deps ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -839,7 +839,6 @@ parts:
     override-pull: |
       set -eux
       craftctl default
-      meson subprojects download
       sed -i 's#Werror=missing-include-dirs#Wmissing-include-dirs#g' meson.build
 
   libdazzle:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -860,35 +860,8 @@ parts:
       craftctl default
       sed -i 's#Werror=missing-include-dirs#Wmissing-include-dirs#g' meson.build
 
-  libcanberra:
-    after: [ libdazzle ]
-    source: http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz
-# ext:updatesnap
-#   version-format:
-#     ignore: true
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=/usr
-      - --with-builtin=pulse
-    build-environment: *buildenv
-    override-pull: |
-      craftctl default
-      for p in $CRAFT_PROJECT_DIR/patches/libcanberra/*.patch; do
-        patch -p1 < "$p"
-      done
-    override-build: |
-      ./autogen.sh
-      craftctl default
-    build-packages:
-      - libasound2-dev
-      - libvorbis-dev
-      - libtdb-dev
-      - libpulse-dev
-      - libgstreamer1.0-dev
-      - libltdl-dev
-
   gsound:
-    after: [ libcanberra, meson-deps, vala, gobject-introspection ]
+    after: [ meson-deps, vala, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gsound.git
     source-tag: '1.0.3'
     source-depth: 1
@@ -901,6 +874,9 @@ parts:
       - -Dintrospection=true
       - -Denable_vala=true
     build-environment: *buildenv
+    build-packages:
+      - libcanberra-dev
+      - libcanberra-gtk3-dev
 
   gsettings-desktop-schemas:
     after: [ gsound, meson-deps, gobject-introspection ]
@@ -1422,6 +1398,7 @@ parts:
       - libbz2-dev
       - libcairo2-dev
       - libcanberra-gtk3-dev
+      - libcanberra-pulse
       - libcrypt-dev
       - libcurl4-openssl-dev
       - libdbus-1-3

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1360,13 +1360,23 @@ parts:
 
   debs:
     after:
+      - atkmm
       - at-spi2-core
+      - cairomm
+      - glibmm
+      - gtk-locales
+      - gtkmm
+      - gtksourceview
       - libadwaita
       - libayatana-appindicator
+      - libdazzle
       - libgnome-games-support
       - libgweather
+      - libportal
       - librest
       - libsoup3
+      - mm-common
+      - pangomm
       - webp-pixbuf-loader
     plugin: nil
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -372,9 +372,11 @@ parts:
     build-environment: *buildenv
     build-packages:
       - libssl-dev
+      - meson
       - curl
     override-pull: |
       craftctl default
+      meson subprojects download
       # cargo version in .deb is too old
       curl https://sh.rustup.rs -sSf > cargo.sh
       sh ./cargo.sh -y
@@ -434,9 +436,11 @@ parts:
     build-packages:
       - libidn2-dev
       - libunistring-dev
+      - meson
     override-pull: |
       set -eux
       craftctl default
+      meson subprojects download
       sed -i 's#^\#!/usr/bin/env python$#\#!/usr/bin/env python3#g' src/psl-make-dafsa
 
   libsoup3:
@@ -538,8 +542,10 @@ parts:
       - libxi-dev
       - libxkbfile-dev
       - libxml2-utils
+      - meson
     override-pull: |
       craftctl default
+      meson subprojects download
       patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
 
   gtk4:
@@ -632,8 +638,10 @@ parts:
       - libsystemd-dev
       - gperf
       - libappstream-dev
+      - meson
     override-pull: |
       craftctl default
+      meson subprojects download
       patch -p1 < $CRAFT_PROJECT_DIR/patches/stylesheet-common-Use-disabled-opacity-for-disabled-pictu.patch
       patch -p1 < $CRAFT_PROJECT_DIR/patches/stylesheet-common-Use-opacity-for-all-disabled-gtk-images.patch
       patch -p1 < $CRAFT_PROJECT_DIR/patches/accent-color-Return-return-orange-as-default-color.patch
@@ -828,9 +836,11 @@ parts:
     build-packages:
       - gettext
       - libxml2-dev
+      - meson
     override-pull: |
       set -eux
       craftctl default
+      meson subprojects download
       sed -i 's#Werror=missing-include-dirs#Wmissing-include-dirs#g' meson.build
 
   libdazzle:
@@ -1142,6 +1152,11 @@ parts:
       - -Ddebug=true
       - -Dtests=false
     build-environment: *buildenv
+    build-packages:
+      - meson
+    override-pull: |
+      craftctl default
+      meson subprojects download
 
   libhandy:
     after: [ pygobject, meson-deps, vala, gobject-introspection ]
@@ -1274,10 +1289,12 @@ parts:
       - -Denable_vala=true
     override-pull: |
       craftctl default
+      meson subprojects download
       patch -p1 < $CRAFT_PROJECT_DIR/patches/libgweather.diff
       sed -i "s#CRAFT_ENV_REPLACE#/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#" $CRAFT_PART_SRC/data/meson.build
     build-packages:
       - gir1.2-glib-2.0
+      - meson
 
   webp-pixbuf-loader:
     after: [meson-deps, gdk-pixbuf]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -77,6 +77,7 @@ parts:
       sed -i "s%^#!/usr/bin/python3$%#!/usr/bin/env python3%g" $CRAFT_PART_INSTALL/usr/bin/meson
     build-packages:
       - python3-pip
+      - meson
 
   libtool:
     plugin: nil
@@ -373,7 +374,6 @@ parts:
     build-environment: *buildenv
     build-packages:
       - libssl-dev
-      - meson
       - curl
     override-pull: |
       craftctl default
@@ -438,7 +438,6 @@ parts:
     build-packages:
       - libidn2-dev
       - libunistring-dev
-      - meson
     override-pull: |
       set -eux
       craftctl default
@@ -544,7 +543,6 @@ parts:
       - libxi-dev
       - libxkbfile-dev
       - libxml2-utils
-      - meson
     override-pull: |
       craftctl default
       patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
@@ -639,7 +637,6 @@ parts:
       - libsystemd-dev
       - gperf
       - libappstream-dev
-      - meson
     override-pull: |
       craftctl default
       meson subprojects download
@@ -837,7 +834,6 @@ parts:
     build-packages:
       - gettext
       - libxml2-dev
-      - meson
     override-pull: |
       set -eux
       craftctl default
@@ -1128,8 +1124,6 @@ parts:
       - -Ddebug=true
       - -Dtests=false
     build-environment: *buildenv
-    build-packages:
-      - meson
     override-pull: |
       craftctl default
       meson subprojects download
@@ -1270,7 +1264,6 @@ parts:
       sed -i "s#CRAFT_ENV_REPLACE#/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#" $CRAFT_PART_SRC/data/meson.build
     build-packages:
       - gir1.2-glib-2.0
-      - meson
 
   webp-pixbuf-loader:
     after: [meson-deps, gdk-pixbuf]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -381,6 +381,7 @@ parts:
       curl https://sh.rustup.rs -sSf > cargo.sh
       sh ./cargo.sh -y
       export PATH=$PATH:$HOME/.cargo/bin
+      ~/.cargo/bin/cargo update
       ~/.cargo/bin/cargo install cargo-c --locked
       cp ~/.cargo/bin/* /usr/local/bin
     override-stage: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -545,7 +545,6 @@ parts:
       - meson
     override-pull: |
       craftctl default
-      meson subprojects download
       patch -p1 < $CRAFT_PROJECT_DIR/patches/gdkglcontext-wayland-Fallback-to-GLES-2_0-after-GL-failed.patch
 
   gtk4:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1680,6 +1680,9 @@ parts:
       - python3-pip
       - zip
       - python3-apt
+    override-pull: |
+      craftctl default
+      python3 -m pip install --break-system-packages pyyaml pyelftools
     override-prime: |
       set -eux
 
@@ -1711,7 +1714,6 @@ parts:
       mkdir -p $DEBUG_BUILDID
 
       OLDPATH=$PATH
-      python3 -m pip install --break-system-packages pyyaml pyelftools
       $CRAFT_PROJECT_DIR/tools/strip_binaries.py $CRAFT_PRIME $DEBUG_BUILDID
       PATH=$OLDPATH
       echo Symbols compressed


### PR DESCRIPTION
In Launchpad, Risc builds fail when Meson attempts to pull subprojects late.

Build attempts at https://launchpad.net/~nteodosio/+snap/sdk-46-pull-early-for-risc.