### PR TITLE
Fix python version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -290,6 +290,7 @@ parts:
     make-parameters:
       - PLATFORM_PLUG=$SNAPCRAFT_PROJECT_NAME
       - WITH_GRAPHICS=false
+      - WITH_PYTHON=3.12
 
   cleanup:
     after: [ caches ]


### PR DESCRIPTION
The python version defined in snapcraft-desktop-integration is 3.10, which is wrong. The right value is 3.12.

Since the value should be overrode using Make parameters, this patch fixes this by specifying the right value when building the command chain.