### PR TITLE
feat: Use mesa 25.2 backported to core22

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,10 +32,14 @@ slots:
       read:
         - /
 
+package-repositories:
+  - type: apt
+    ppa: desktop-snappers/core22-mesa-backports
+
 parts:
   gnome-sdk:
     plugin: nil
-    stage-snaps: [ gnome-42-2204-sdk/latest/stable ]
+    stage-snaps: [ gnome-42-2204-sdk/latest/edge/core22-mesa-backport ]
     override-build: |
       set -eu
       craftctl default

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -294,6 +294,7 @@ parts:
   command-chain:
     source: https://github.com/snapcore/snapcraft-desktop-integration.git
     source-type: git
+    source-branch: gbm_backends_path
     source-subdir: gnome
     plugin: make
     make-parameters:


### PR DESCRIPTION
This includes Mesa 25.2.8 from a backport PPA which enables more recent Intel hardware and includes significant battery usage improvements for more recent AMD hardware.

https://launchpad.net/~desktop-snappers/+archive/ubuntu/core22-mesa-backports