### PR TITLE
Add missing mesa-va-drivers to deb-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1649,6 +1649,7 @@ parts:
       - libxtst-dev
       - libyaml-0-2
       - libzstd1
+      - mesa-va-drivers
       - pkg-config
       - python3-dev
       - python3-distutils


### PR DESCRIPTION
I noticed that the symlink for radeonsi is not there, I suspect this is the wrong one.

Currently:
```
$ ls -lah usr/lib/x86_64-linux-gnu/dri/radeonsi_drv*
-rw-r--r-- 5 root root 15M Oct  9  2024 usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so
```

After rebuilding with this change:
```
$ ls -lah usr/lib/x86_64-linux-gnu/dri/radeonsi_drv*
lrwxrwxrwx 1 root root 48 May 23  2025 usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so -> ../libgallium-25.2.8-0ubuntu0~bpo22.04.1~ppa1.so
```