### PR TITLE
ci: Fix lack of free disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android
     - uses: snapcore/action-build@v1
       id: snapcraft
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, CI build fails due to lack of free disk space.

This patch fixes it by removing the Android SDK from the build image.