### PR TITLE
fix: The mesa backport was only for amd64, fallback gracefully

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -192,7 +192,6 @@ parts:
       - libjbig0
       - libjpeg-turbo8
       - liblcms2-2
-      - libllvm20
       - libmozjs-91-0
       - libmpc3
       - libmpfr6
@@ -248,6 +247,9 @@ parts:
       - on amd64:
         - i965-va-driver
         - intel-media-va-driver
+        - libllvm20
+      - else:
+        - libllvm11
     stage:
       - -usr/lib/$CRAFT_ARCH_TRIPLET/libLLVM*
     override-build: |


### PR DESCRIPTION
The mesa backport was only for amd64, so fallback gracefully on other architectures.