### PR TITLE
Use salsa.debian.org for canberra library

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -967,7 +967,9 @@ parts:
 
   libcanberra:
     after: [ libdazzle ]
-    source: http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz
+    source: https://salsa.debian.org/gnome-team/libcanberra.git
+    source-depth: 1
+    source-tag: ubuntu/0.30-18ubuntu1
 # ext:updatesnap
 #   version-format:
 #     ignore: true


### PR DESCRIPTION
The canberra library is quite old, so no new updates are expected. For this reason it was downloaded from Lennart Poetering web. Unfortunately, the web seems to have broken, which means that this is fragile.

This patch uses the salsa.debian.org repository instead.