### PR TITLE
Use candidate instead of stable for the base SDK

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,7 +39,7 @@ package-repositories:
 parts:
   gnome-sdk:
     plugin: nil
-    stage-snaps: [ gnome-42-2204-sdk/latest/stable ]
+    stage-snaps: [ gnome-42-2204-sdk/latest/candidate ]
     override-build: |
       set -eu
       craftctl default


### PR DESCRIPTION
Currently, the runtime is being built from the stable SDK, which is wrong because we build the runtime to upload it co candidate, and only promote it to stable when we consider that the candidate is ready.

This patch fixes this.