### PR TITLE
Add DoNotBuild option to the build script

### DIFF
--- a/local-build.py
+++ b/local-build.py
@@ -46,6 +46,8 @@ gnome_part['build-environment'] = gnome_part.get('build-environment', []) + [
 try:
     with open(f'./{MODIFIED_CONFIG}', "w") as config_file:
         config_file.write(yaml.dump(config, Dumper=yaml.Dumper))
+    if "--prepare-only" in sys.argv:
+        sys.exit(0)
 
     os.system('snapcraft clean')
     os.system('snapcraft pack -v')


### PR DESCRIPTION
This option just creates the new snapcraft.yaml file but doesn't build the snap. It is required for github CI.