### PR TITLE
Move base sdk snap into a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This snap builds the GNOME-46-2404 runtime from the corresponding GNOME-46-2404-
 snap.
 
 By default, it will get the SDK from the store, from the CANDIDATE branch; but it is
-possible to use a different SDK (for example, one built locally), putting it in the
-project root folder, renaming it to `gnome-46-2404-sdk.snap`, and launching the
+possible to use a different SDK (for example, one built locally), by creating a folder
+called `base-gnome-sdk`, putting it inside, and launching the
 `local-build.py` script. It will create a new, modified `snapcraft.yaml` file in the,
 project's root, clean the snapcraft build environment, build the new snap, and restore
 the `snapcraft.yaml` file. This is useful if you do a change in the SDK and want

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ project's root, clean the snapcraft build environment, build the new snap, and r
 the `snapcraft.yaml` file. This is useful if you do a change in the SDK and want
 to test it, to ensure that everything works as expected and nothing breaks.
 
+If the script finds several `snap` files inside the `base-gnome-sdk` folder, it will
+use the most recent one, based on the modification time of the file.
+
+Also, if the build must be done by an external script (like when using Github's CI),
+then it is possible to call the `local-build.py` script with the `--prepare-only`
+parameter. With it, it will just generate the modified `snapcraft.yaml` file in the
+project folder, nothing else.
+
 ## Getting the repository
 
 To get the repository, just run:

--- a/local-build.py
+++ b/local-build.py
@@ -19,14 +19,25 @@ yaml.representer.SafeRepresenter.add_representer(str, str_presenter) # to use wi
 
 BASE_CONFIG = 'snap/snapcraft.yaml'
 MODIFIED_CONFIG = 'snapcraft.yaml'
-SDK_FILE = 'gnome-46-2404-sdk.snap'
+BASE_SNAP_FOLDER = 'base-gnome-sdk'
+SDK_FILE = None
 
 # If there is a modified snapcraft.yaml, delete it before re-generating it
 if os.path.exists(f'./{MODIFIED_CONFIG}'):
     os.remove(f'./{MODIFIED_CONFIG}')
 
-if not os.path.exists(f'./{SDK_FILE}'):
-    print(f'There is no valid "{SDK_FILE}" file. Aborting.', file=sys.stderr)
+last_time = None
+# get the most recent snap
+for f in os.listdir(BASE_SNAP_FOLDER):
+    if f.endswith(".snap"):
+        fullpath = os.path.join(BASE_SNAP_FOLDER, f)
+        now_time = os.path.getmtime(fullpath)
+        if (last_time is None) or (now_time > last_time):
+            SDK_FILE = fullpath
+            last_time = now_time
+
+if SDK_FILE is None:
+    print(f'There is no valid SDK file in the {BASE_SNAP_FOLDER} folder. Aborting.', file=sys.stderr)
     sys.exit(1)
 
 with open(f'./{BASE_CONFIG}', "r") as config_file:
@@ -46,10 +57,9 @@ gnome_part['build-environment'] = gnome_part.get('build-environment', []) + [
 try:
     with open(f'./{MODIFIED_CONFIG}', "w") as config_file:
         config_file.write(yaml.dump(config, Dumper=yaml.Dumper))
-    if "--prepare-only" in sys.argv:
-        sys.exit(0)
-
-    os.system('snapcraft clean')
-    os.system('snapcraft pack -v')
+    if "--prepare-only" not in sys.argv:
+        os.system('snapcraft clean')
+        os.system('snapcraft pack -v')
 finally:
-    os.remove(f'./{MODIFIED_CONFIG}')
+    if "--prepare-only" not in sys.argv:
+        os.remove(f'./{MODIFIED_CONFIG}')

--- a/local-build.py
+++ b/local-build.py
@@ -5,6 +5,7 @@
 import sys
 import os
 import yaml
+import glob
 
 def str_presenter(dumper, data):
     """configures yaml for dumping multiline strings
@@ -21,20 +22,19 @@ BASE_CONFIG = 'snap/snapcraft.yaml'
 MODIFIED_CONFIG = 'snapcraft.yaml'
 BASE_SNAP_FOLDER = 'base-gnome-sdk'
 SDK_FILE = None
+PREPARE_ONLY_OPTION = '--prepare-only'
 
 # If there is a modified snapcraft.yaml, delete it before re-generating it
 if os.path.exists(f'./{MODIFIED_CONFIG}'):
     os.remove(f'./{MODIFIED_CONFIG}')
 
 last_time = None
-# get the most recent snap
-for f in os.listdir(BASE_SNAP_FOLDER):
-    if f.endswith(".snap"):
-        fullpath = os.path.join(BASE_SNAP_FOLDER, f)
-        now_time = os.path.getmtime(fullpath)
-        if (last_time is None) or (now_time > last_time):
-            SDK_FILE = fullpath
-            last_time = now_time
+# If there are more than one snap, use the most recent one
+for fullpath in glob.glob(os.path.join(BASE_SNAP_FOLDER, "*.snap")):
+    now_time = os.path.getmtime(fullpath)
+    if (last_time is None) or (now_time > last_time):
+        SDK_FILE = fullpath
+        last_time = now_time
 
 if SDK_FILE is None:
     print(f'There is no valid SDK file in the {BASE_SNAP_FOLDER} folder. Aborting.', file=sys.stderr)
@@ -57,9 +57,9 @@ gnome_part['build-environment'] = gnome_part.get('build-environment', []) + [
 try:
     with open(f'./{MODIFIED_CONFIG}', "w") as config_file:
         config_file.write(yaml.dump(config, Dumper=yaml.Dumper))
-    if "--prepare-only" not in sys.argv:
+    if PREPARE_ONLY_OPTION not in sys.argv:
         os.system('snapcraft clean')
         os.system('snapcraft pack -v')
 finally:
-    if "--prepare-only" not in sys.argv:
+    if PREPARE_ONLY_OPTION not in sys.argv:
         os.remove(f'./{MODIFIED_CONFIG}')


### PR DESCRIPTION
If there are several snaps in the main folder, the build action gets confused and returns the wrong snap (in this case, the SDK snap).

This patch moves the SDK snap into a folder to ensure that only the built runtime snap is in the main folder.

Also ensures not to remove the snapcraft.yaml file when using --prepare-only.