### PR TITLE
Allow to build runtime from custom sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ snap.
 By default, it will get the SDK from the store, from the CANDIDATE branch; but it is
 possible to use a different SDK (for example, one built locally), by creating a folder
 called `base-gnome-sdk`, putting it inside, and launching the
-`local-build.py` script. It will create a new, modified `snapcraft.yaml` file in the,
+`local-build.py` script. It will create a new, modified `snapcraft.yaml` file in the
 project's root, clean the snapcraft build environment, build the new snap, and restore
 the `snapcraft.yaml` file. This is useful if you do a change in the SDK and want
 to test it, to ensure that everything works as expected and nothing breaks.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-git clone -b gnome-42-2204 https://github.com/ubuntu/gnome-sdk.git gnome-42-2204
+# GNOME-42-2204 runtime
+
+This snap builds the GNOME-42-2204 runtime from the corresponding GNOME-42-2204-SDK
+snap.
+
+By default, it will get the SDK from the store, from the CANDIDATE branch; but it is
+possible to use a different SDK (for example, one built locally), by creating a folder
+called `base-gnome-sdk`, putting it inside, and launching the
+`local-build.py` script. It will create a new, modified `snapcraft.yaml` file in the,
+project's root, clean the snapcraft build environment, build the new snap, and restore
+the `snapcraft.yaml` file. This is useful if you do a change in the SDK and want
+to test it, to ensure that everything works as expected and nothing breaks.
+
+If the script finds several `snap` files inside the `base-gnome-sdk` folder, it will
+use the most recent one, based on the modification time of the file.
+
+Also, if the build must be done by an external script (like when using Github's CI),
+then it is possible to call the `local-build.py` script with the `--prepare-only`
+parameter. With it, it will just generate the modified `snapcraft.yaml` file in the
+project folder, nothing else.
+
+## Getting the repository
+
+To get the repository, just run:
+
+    git clone -b gnome-42-2204 https://github.com/ubuntu/gnome-sdk.git gnome-42-2204
 
 This branch is used to build [the gnome-42-2204 snap](https://launchpad.net/~desktop-snappers/+snap/gnome-42-2204),
 which in turn uses the [the gnome-42-2204-sdk snap](https://launchpad.net/~desktop-snappers/+snap/gnome-42-2204-sdk).

--- a/local-build.py
+++ b/local-build.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# This script builds the gnome runtime snap using a local SDK snap.
+
+import sys
+import os
+import subprocess
+import yaml
+import glob
+
+def str_presenter(dumper, data):
+    """configures yaml for dumping multiline strings
+    Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data
+    Ensures that the scripts are dumped in the right multiline format """
+    if len(data.splitlines()) > 1:  # check for multiline string
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+yaml.add_representer(str, str_presenter)
+yaml.representer.SafeRepresenter.add_representer(str, str_presenter) # to use with safe_dum
+
+BASE_CONFIG = 'snap/snapcraft.yaml'
+MODIFIED_CONFIG = 'snapcraft.yaml'
+BASE_SNAP_FOLDER = 'base-gnome-sdk'
+SDK_FILE = None
+PREPARE_ONLY_OPTION = '--prepare-only'
+
+# If there is a modified snapcraft.yaml, delete it before re-generating it
+if os.path.exists(f'./{MODIFIED_CONFIG}'):
+    os.remove(f'./{MODIFIED_CONFIG}')
+
+last_time = None
+# If there are more than one snap, use the most recent one
+for fullpath in glob.glob(os.path.join(BASE_SNAP_FOLDER, "*.snap")):
+    now_time = os.path.getmtime(fullpath)
+    if (last_time is None) or (now_time > last_time):
+        SDK_FILE = fullpath
+        last_time = now_time
+
+if SDK_FILE is None:
+    print(f'There is no valid SDK file in the {BASE_SNAP_FOLDER} folder. Aborting.', file=sys.stderr)
+    sys.exit(1)
+
+with open(f'./{BASE_CONFIG}', "r") as config_file:
+    config = yaml.load(config_file, Loader=yaml.Loader)
+
+gnome_part = config['parts']['gnome-sdk']
+
+# remove the stage-snaps entry
+del gnome_part['stage-snaps']
+
+version = config['name'].split('-')[1]
+gnome_part['build-environment'] = gnome_part.get('build-environment', []) + [
+    {'LOCAL_SDK_SNAP': SDK_FILE},
+    {'sdk_version': version}
+]
+
+try:
+    with open(f'./{MODIFIED_CONFIG}', "w") as config_file:
+        config_file.write(yaml.dump(config, Dumper=yaml.Dumper))
+    if PREPARE_ONLY_OPTION not in sys.argv:
+        subprocess.call('snapcraft clean', shell=True)
+        subprocess.call('snapcraft pack -v', shell=True)
+finally:
+    if PREPARE_ONLY_OPTION not in sys.argv:
+        os.remove(f'./{MODIFIED_CONFIG}')

--- a/local-build.py
+++ b/local-build.py
@@ -4,7 +4,6 @@
 
 import sys
 import os
-import subprocess
 import yaml
 import glob
 
@@ -59,8 +58,8 @@ try:
     with open(f'./{MODIFIED_CONFIG}', "w") as config_file:
         config_file.write(yaml.dump(config, Dumper=yaml.Dumper))
     if PREPARE_ONLY_OPTION not in sys.argv:
-        subprocess.call('snapcraft clean', shell=True)
-        subprocess.call('snapcraft pack -v', shell=True)
+        os.system('snapcraft clean')
+        os.system('snapcraft pack -v')
 finally:
     if PREPARE_ONLY_OPTION not in sys.argv:
         os.remove(f'./{MODIFIED_CONFIG}')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,10 +27,10 @@ compression: lzo
 
 # the recommended mountpoint for that content is /gnome-platform
 slots:
-    gnome-42-2204:
-      interface: content
-      read:
-        - /
+  gnome-42-2204:
+    interface: content
+    read:
+      - /
 
 package-repositories:
   - type: apt
@@ -39,12 +39,25 @@ package-repositories:
 parts:
   gnome-sdk:
     plugin: nil
-    stage-snaps: [ gnome-42-2204-sdk/latest/candidate ]
+    stage-snaps:
+      - gnome-42-2204-sdk/latest/candidate
     override-build: |
       set -eu
       craftctl default
-      sdk_version=$(sed -n  's/^version:\s*\(.*\)/\1/p' \
-        ${CRAFT_PART_INSTALL}/snap.gnome-42-2204-sdk/manifest.yaml)
+      # LOCAL_SDK_SNAP is set by `local-build.py` when using a local snap
+      if [ -z "${LOCAL_SDK_SNAP:-}" ]; then
+        echo Using upstream SDK
+        sdk_version=$(sed -n  's/^version:\s*\(.*\)/\1/p' \
+          ${CRAFT_PART_INSTALL}/snap.gnome-42-2204-sdk/manifest.yaml)
+      else
+        echo Using local $CRAFT_PROJECT_DIR/${LOCAL_SDK_SNAP}
+        snap install --dangerous $CRAFT_PROJECT_DIR/${LOCAL_SDK_SNAP}
+
+        cp -a /snap/gnome-42-2204-sdk/current/usr $CRAFT_PART_INSTALL/
+        cp -a /snap/gnome-42-2204-sdk/current/etc $CRAFT_PART_INSTALL/
+        cp -a /snap/gnome-42-2204-sdk/current/var $CRAFT_PART_INSTALL/
+        cp -a /snap/gnome-42-2204-sdk/current/lib $CRAFT_PART_INSTALL/
+      fi
 
       # Use the same logic of snapcraft
       project_version=$(git -C "${CRAFT_PROJECT_DIR}" describe --dirty 2>/dev/null || true)
@@ -56,7 +69,7 @@ parts:
     stage:
       - lib/*/bindtextdomain.so
       - usr
-      - lib/$CRAFT_ARCH_TRIPLET/*
+      - lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/*
       - etc/gnome/*
       - -etc/emacs
       - -etc/X11/Xreset.d/README
@@ -74,7 +87,7 @@ parts:
       - -usr/share/installed-tests
       - -usr/share/maven-repo
       - -usr/bin/dpkg*
-      - -usr/bin/$CRAFT_ARCH_TRIPLET-*
+      - -usr/bin/$CRAFT_ARCH_TRIPLET_BUILD_FOR-*
       - -usr/bin/g-ir-*
       - -usr/bin/glib-compile-*
       - -usr/bin/glib-gettextize
@@ -142,7 +155,8 @@ parts:
       - -usr/share/devhelp/books
 
   debs:
-    after: [ gnome-sdk ]
+    after:
+      - gnome-sdk
     plugin: nil
     stage-packages:
       - fcitx-frontend-gtk3
@@ -251,7 +265,7 @@ parts:
       - else:
         - libllvm11
     stage:
-      - -usr/lib/$CRAFT_ARCH_TRIPLET/libLLVM*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libLLVM*
     override-build: |
       set -eux
       craftctl default
@@ -259,29 +273,80 @@ parts:
       find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/{} \;
       find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/{}*" \;
       cd $CRAFT_STAGE/usr/lib
-      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/{} \;
-      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/{}*" \;
-      cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET
+      find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{} \;
+      find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/{}*" \;
+      cd $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       find . -type f,l -exec rm -f $CRAFT_PART_INSTALL/usr/lib/{} \;
       find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/{}*" \;
 
   fonts-config:
-      after: [ debs ]
-      plugin: nil
-      stage-packages: [ fontconfig-config, fonts-arphic-ukai, fonts-arphic-uming, fonts-beng-extra, fonts-dejavu-core, fonts-deva-extra, fonts-droid-fallback, fonts-gubbi, fonts-gujr-extra, fonts-guru-extra, fonts-lohit-beng-assamese, fonts-lohit-beng-bengali, fonts-lohit-deva, fonts-lohit-gujr, fonts-lohit-guru, fonts-lohit-knda, fonts-lohit-mlym, fonts-lohit-orya, fonts-lohit-taml, fonts-lohit-taml-classical, fonts-lohit-telu, fonts-noto-cjk, fonts-noto-mono, fonts-orya-extra, fonts-pagul, fonts-smc-anjalioldlipi, fonts-smc-chilanka, fonts-smc-dyuthi, fonts-smc-karumbi, fonts-smc-keraleeyam, fonts-smc-manjari, fonts-smc-meera, fonts-smc-rachana, fonts-smc-raghumalayalamsans, fonts-smc-suruma, fonts-smc-uroob, fonts-telu-extra, fonts-tlwg-garuda, fonts-tlwg-kinnari, fonts-tlwg-laksaman, fonts-tlwg-loma, fonts-tlwg-mono, fonts-tlwg-norasi, fonts-tlwg-typist, fonts-tlwg-typo, fonts-tlwg-umpush, fonts-tlwg-waree, fonts-urw-base35, language-selector-common ]
-      stage:
+    after:
+      - debs
+    plugin: nil
+    stage:
       - etc/fonts
       - usr/share/fontconfig
+    stage-packages:
+      - fontconfig-config
+      - fonts-arphic-ukai
+      - fonts-arphic-uming
+      - fonts-beng-extra
+      - fonts-dejavu-core
+      - fonts-deva-extra
+      - fonts-droid-fallback
+      - fonts-gubbi
+      - fonts-gujr-extra
+      - fonts-guru-extra
+      - fonts-lohit-beng-assamese
+      - fonts-lohit-beng-bengali
+      - fonts-lohit-deva
+      - fonts-lohit-gujr
+      - fonts-lohit-guru
+      - fonts-lohit-knda
+      - fonts-lohit-mlym
+      - fonts-lohit-orya
+      - fonts-lohit-taml
+      - fonts-lohit-taml-classical
+      - fonts-lohit-telu
+      - fonts-noto-cjk
+      - fonts-noto-mono
+      - fonts-orya-extra
+      - fonts-pagul
+      - fonts-smc-anjalioldlipi
+      - fonts-smc-chilanka
+      - fonts-smc-dyuthi
+      - fonts-smc-karumbi
+      - fonts-smc-keraleeyam
+      - fonts-smc-manjari
+      - fonts-smc-meera
+      - fonts-smc-rachana
+      - fonts-smc-raghumalayalamsans
+      - fonts-smc-suruma
+      - fonts-smc-uroob
+      - fonts-telu-extra
+      - fonts-tlwg-garuda
+      - fonts-tlwg-kinnari
+      - fonts-tlwg-laksaman
+      - fonts-tlwg-loma
+      - fonts-tlwg-mono
+      - fonts-tlwg-norasi
+      - fonts-tlwg-typist
+      - fonts-tlwg-typo
+      - fonts-tlwg-umpush
+      - fonts-tlwg-waree
+      - fonts-urw-base35
+      - language-selector-common
 
   caches:
-    after: [ fonts-config ]
+    after:
+      - fonts-config
     plugin: nil
     build-packages:
       - gtk-update-icon-cache
       - libglib2.0-bin
       - shared-mime-info
     build-environment:
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     override-build: |
       set -eux
       craftctl default
@@ -302,7 +367,8 @@ parts:
       - PLATFORM_PLUG=$SNAPCRAFT_PROJECT_NAME
 
   cleanup:
-    after: [ caches ]
+    after:
+      - caches
     plugin: nil
     build-snaps:
       - gtk-common-themes


### PR DESCRIPTION
This patch adapts the script from gnome-46-2404 that allows to build the Runtime from a custom, prebuilt SDK. It is needed to be able to test any PR in the SDK using CI.

It also fixes the CRAFT_ARCH_TRIPLET warnings.