### PR TITLE
Fix libwoff 

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1559,6 +1559,7 @@ parts:
       - libwayland-dev
       - libwebkit2gtk-4.1-dev
       - libwebp-dev
+      - libwoff1
       - libwrap0
       - libwrap0-dev
       - libx11-xcb-dev


### PR DESCRIPTION
For some reason, libwoff isn't available anymore when building the SDK/Runtime, but it is required for Epiphany (this is why new builds don't pass the CI tests). This patch fix this.

It also removes the bash-completion files, which aren't needed, neither in the SDK nor in the runtime.