### PR TITLE
Remove bash-completion files

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1737,6 +1737,7 @@ parts:
       rm -rf usr/share/doc
       rm -rf usr/share/gtk-doc
       rm -rf usr/share/man
+      rm -rf usr/share/bash-completion
       find usr -type d -name installed-tests -exec rm -rfv '{}' \; || true
       find usr -type f,l -name '*.la' -print -delete;
 


### PR DESCRIPTION
The bash-completion files aren't needed, so we can safely remove them and save a little bit of space. Also, when the future test for added and removed files is added, there will be less things that will trigger false alarms.