### PR TITLE
Add libc6 to fix broken symlink

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -87,6 +87,7 @@ parts:
     stage-packages:
       - libtool
       - libtool-bin
+      - libc6
     override-stage: |
       set -eux
       craftctl default


### PR DESCRIPTION
Libtool part stages several packages, including libc6-dev indirectly due to dependencies. This results in a broken link for libc6, which breaks Risc-v and Armhf build.

This PR fixes it. Tested in a Raspberry Pi with Ubuntu server 32 bits.