### PR TITLE
Use fcitx5 frontend instead of fcitx 4 one.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,7 +166,7 @@ parts:
     after: [ gnome-sdk ]
     plugin: nil
     stage-packages:
-      - fcitx-frontend-gtk3
+      - fcitx5-frontend-gtk3
       - fonts-noto-color-emoji
       - gir1.2-ggit-1.0
       - gir1.2-gucharmap-2.90


### PR DESCRIPTION
1. fcitx5 one has compatibility for new fcitx 4 (4.2.9.7+) via org.freedesktop.portal.Fcitx
2. Required apparmor dbus interface support is added for apparmor 4.1.0+ and snapd 2.61+, 26 runtime seems to be a better option to start using it.

Reference:
[1] snapd: https://github.com/canonical/snapd/commit/c2e71874f10c2971260a28d423898da714deb190
[2] apparmor: https://gitlab.com/apparmor/apparmor/-/commit/e1de0bb5d503d8b977290d0145c47765bbe8229e