### PR TITLE
[core24] snapcraft/gsettings-desktop-schemas: Add accent colors support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           - snapname: "telegram-desktop"
             waittext: "Welcome to the official Telegram Desktop app"
           - snapname: "thunderbird"
-            waittext: "Thunderbird will automatically search"
+            waittext: "Add your email address"
     runs-on: ubuntu-latest
     needs: snap
     steps:

--- a/patches/gsettings-desktop-schemas/001-headers-schemas-Backport-font-rendering-from-47.patch
+++ b/patches/gsettings-desktop-schemas/001-headers-schemas-Backport-font-rendering-from-47.patch
@@ -1,0 +1,45 @@
+From: gnome-sdk <noreply@ubuntu.com>
+Date: Wed, 19 Jun 2024 07:00:00 -0700
+Subject: headers/schemas: Backport font-rendering setting from 47
+
+Backport the GDesktopFontRendering enum and the "font-rendering" schema
+key from the 47 series so that the accent-color backport patches (which
+were authored on top of it) apply as-is on the 46.1 sources.
+
+The enum is intentionally introduced with the original "typdef" typo so
+that the following "headers: Fix typo" patch applies unchanged.
+---
+diff --git a/headers/gdesktop-enums.h b/headers/gdesktop-enums.h
+index 4a9c5fa..d126447 100644
+--- a/headers/gdesktop-enums.h
++++ b/headers/gdesktop-enums.h
+@@ -265,4 +265,10 @@ typedef enum
+   G_DESKTOP_POINTING_STICK_SCROLL_METHOD_ON_BUTTON_DOWN
+ } GDesktopPointingStickScrollMethod;
+ 
++typdef enum
++{
++  G_DESKTOP_FONT_RENDERING_AUTOMATIC,
++  G_DESKTOP_FONT_RENDERING_MANUAL,
++} GDesktopFontRendering;
++
+ #endif /* __gdesktop_enums_h__ */
+diff --git a/schemas/org.gnome.desktop.interface.gschema.xml.in b/schemas/org.gnome.desktop.interface.gschema.xml.in
+index 10fca74..aef8db6 100644
+--- a/schemas/org.gnome.desktop.interface.gschema.xml.in
++++ b/schemas/org.gnome.desktop.interface.gschema.xml.in
+@@ -302,5 +302,14 @@
+         The preferred color scheme for the user interface. Valid values are “default”, “prefer-dark”, “prefer-light”.
+       </description>
+     </key>
++    <key name="font-rendering" enum="org.gnome.desktop.GDesktopFontRendering">
++      <default>'automatic'</default>
++      <summary>Font rendering</summary>
++      <description>
++        Preference to indicate whether font rendering should follow the low-level `font-hinting` and `font-antialiasing` and `font-rgba-order` settings, or take environmental factors such as screen resolution and scaling into account.
++        Possible values are: "manual" for respecting the low-level settings, or "automatic" for letting the toolkit
++        make its own decisions.
++      </description>
++    </key>
+   </schema>
+ </schemalist>

--- a/patches/gsettings-desktop-schemas/002-headers-Fix-typo.patch
+++ b/patches/gsettings-desktop-schemas/002-headers-Fix-typo.patch
@@ -1,0 +1,26 @@
+From 932bc622504c812565fdee3e558e07540a3d6df8 Mon Sep 17 00:00:00 2001
+From: Jamie Murphy <hello@itsjamie.dev>
+Date: Wed, 19 Jun 2024 07:48:24 -0700
+Subject: [PATCH] headers: Fix typo
+
+typdef instead of typedef
+---
+ headers/gdesktop-enums.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/headers/gdesktop-enums.h b/headers/gdesktop-enums.h
+index d126447..fa7ca59 100644
+--- a/headers/gdesktop-enums.h
++++ b/headers/gdesktop-enums.h
+@@ -265,7 +265,7 @@ typedef enum
+   G_DESKTOP_POINTING_STICK_SCROLL_METHOD_ON_BUTTON_DOWN
+ } GDesktopPointingStickScrollMethod;
+ 
+-typdef enum
++typedef enum
+ {
+   G_DESKTOP_FONT_RENDERING_AUTOMATIC,
+   G_DESKTOP_FONT_RENDERING_MANUAL,
+-- 
+GitLab
+

--- a/patches/gsettings-desktop-schemas/003-schemas-Add-accent-color-key.patch
+++ b/patches/gsettings-desktop-schemas/003-schemas-Add-accent-color-key.patch
@@ -1,0 +1,53 @@
+From 8df894aecbf6908c48c3da62434061bfa8dc46ea Mon Sep 17 00:00:00 2001
+From: Jamie Murphy <hello@itsjamie.dev>
+Date: Wed, 19 Jun 2024 08:14:12 -0700
+Subject: [PATCH] schemas: Add accent color key
+
+Add an entry for configuring the accent color for the system
+---
+ headers/gdesktop-enums.h                           | 13 +++++++++++++
+ schemas/org.gnome.desktop.interface.gschema.xml.in |  7 +++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/headers/gdesktop-enums.h b/headers/gdesktop-enums.h
+index fa7ca59..a17e05d 100644
+--- a/headers/gdesktop-enums.h
++++ b/headers/gdesktop-enums.h
+@@ -271,4 +271,17 @@ typedef enum
+   G_DESKTOP_FONT_RENDERING_MANUAL,
+ } GDesktopFontRendering;
+ 
++typedef enum
++{
++  G_DESKTOP_ACCENT_COLOR_BLUE,
++  G_DESKTOP_ACCENT_COLOR_TEAL,
++  G_DESKTOP_ACCENT_COLOR_GREEN,
++  G_DESKTOP_ACCENT_COLOR_YELLOW,
++  G_DESKTOP_ACCENT_COLOR_ORANGE,
++  G_DESKTOP_ACCENT_COLOR_RED,
++  G_DESKTOP_ACCENT_COLOR_PINK,
++  G_DESKTOP_ACCENT_COLOR_PURPLE,
++  G_DESKTOP_ACCENT_COLOR_SLATE
++} GDesktopAccentColor;
++
+ #endif /* __gdesktop_enums_h__ */
+diff --git a/schemas/org.gnome.desktop.interface.gschema.xml.in b/schemas/org.gnome.desktop.interface.gschema.xml.in
+index aef8db6..e2983c1 100644
+--- a/schemas/org.gnome.desktop.interface.gschema.xml.in
++++ b/schemas/org.gnome.desktop.interface.gschema.xml.in
+@@ -311,5 +311,12 @@
+         make its own decisions.
+       </description>
+     </key>
++    <key name="accent-color" enum="org.gnome.desktop.GDesktopAccentColor">
++      <default>'blue'</default>
++      <summary>Accent color</summary>
++      <description>
++        The preferred accent color for the user interface. Valid values are "blue", "teal", "green", "yellow", "orange", "red", "pink", "purple", "slate".
++      </description>
++    </key>
+   </schema>
+ </schemalist>
+-- 
+GitLab
+

--- a/patches/gsettings-desktop-schemas/004-accent-colors-Add-brown-color-for-temporary-usage.patch
+++ b/patches/gsettings-desktop-schemas/004-accent-colors-Add-brown-color-for-temporary-usage.patch
@@ -1,0 +1,37 @@
+From: =?utf-8?b?Ik1hcmNvIFRyZXZpc2FuIChUcmV2acOxbyki?= <mail@3v1n0.net>
+Date: Thu, 15 Aug 2024 06:31:24 -0400
+Subject: accent-colors: Add brown color for temporary usage
+
+---
+ headers/gdesktop-enums.h                           | 4 +++-
+ schemas/org.gnome.desktop.interface.gschema.xml.in | 2 +-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/headers/gdesktop-enums.h b/headers/gdesktop-enums.h
+index fa5cbfa..8421cc2 100644
+--- a/headers/gdesktop-enums.h
++++ b/headers/gdesktop-enums.h
+@@ -283,7 +283,9 @@ typedef enum
+   G_DESKTOP_ACCENT_COLOR_RED,
+   G_DESKTOP_ACCENT_COLOR_PINK,
+   G_DESKTOP_ACCENT_COLOR_PURPLE,
+-  G_DESKTOP_ACCENT_COLOR_SLATE
++  G_DESKTOP_ACCENT_COLOR_SLATE,
++
++  G_DESKTOP_ACCENT_COLOR_BROWN = G_DESKTOP_ACCENT_COLOR_SLATE + 100,
+ } GDesktopAccentColor;
+ 
+ #endif /* __gdesktop_enums_h__ */
+diff --git a/schemas/org.gnome.desktop.interface.gschema.xml.in b/schemas/org.gnome.desktop.interface.gschema.xml.in
+index e2983c1..82ce8c0 100644
+--- a/schemas/org.gnome.desktop.interface.gschema.xml.in
++++ b/schemas/org.gnome.desktop.interface.gschema.xml.in
+@@ -315,7 +315,7 @@
+       <default>'blue'</default>
+       <summary>Accent color</summary>
+       <description>
+-        The preferred accent color for the user interface. Valid values are "blue", "teal", "green", "yellow", "orange", "red", "pink", "purple", "slate".
++        The preferred accent color for the user interface. Valid values are "blue", "teal", "green", "yellow", "orange", "red", "pink", "purple", "slate", "brown".
+       </description>
+     </key>
+   </schema>

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -650,7 +650,12 @@ parts:
     source: https://gitlab.gnome.org/GNOME/libadwaita.git
     source-tag: '1.7.7'
     source-depth: 1
-    after: [ meson-deps, gtk4, vala, gobject-introspection ]
+    after:
+      - meson-deps
+      - gtk4
+      - vala
+      - gobject-introspection
+      - gsettings-desktop-schemas
     plugin: meson
     meson-parameters:
       - --prefix=/usr

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -923,6 +923,12 @@ parts:
       - -Ddebug=true
       - -Dintrospection=true
     build-environment: *buildenv
+    override-pull: |
+      set -eux
+      craftctl default
+      for patch in $CRAFT_PROJECT_DIR/patches/gsettings-desktop-schemas/*.patch; do
+        patch -p1 < "$patch"
+      done
     override-build: |
       set -eux
       craftctl default


### PR DESCRIPTION
We used to compile the settings schemas without accent color support, thus snaps might be not aware of it, and in particular of the ubuntu-only brown accent.

Also make libadwaita to depend on this, since it uses the GDesktopAccentColor enum.