### PR TITLE
[core26] snapcraft/gsettings-desktop-schemas: Add brown accent color support

### DIFF
--- a/patches/gsettings-desktop-schemas/001-accent-colors-Add-brown-color-for-temporary-usage.patch
+++ b/patches/gsettings-desktop-schemas/001-accent-colors-Add-brown-color-for-temporary-usage.patch
@@ -1,0 +1,37 @@
+From: =?utf-8?b?Ik1hcmNvIFRyZXZpc2FuIChUcmV2acOxbyki?= <mail@3v1n0.net>
+Date: Thu, 15 Aug 2024 06:31:24 -0400
+Subject: accent-colors: Add brown color for temporary usage
+
+---
+ headers/gdesktop-enums.h                           | 4 +++-
+ schemas/org.gnome.desktop.interface.gschema.xml.in | 2 +-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/headers/gdesktop-enums.h b/headers/gdesktop-enums.h
+index 50bfb7c..d5602d1 100644
+--- a/headers/gdesktop-enums.h
++++ b/headers/gdesktop-enums.h
+@@ -289,7 +289,9 @@ typedef enum
+   G_DESKTOP_ACCENT_COLOR_RED,
+   G_DESKTOP_ACCENT_COLOR_PINK,
+   G_DESKTOP_ACCENT_COLOR_PURPLE,
+-  G_DESKTOP_ACCENT_COLOR_SLATE
++  G_DESKTOP_ACCENT_COLOR_SLATE,
++
++  G_DESKTOP_ACCENT_COLOR_BROWN = G_DESKTOP_ACCENT_COLOR_SLATE + 100,
+ } GDesktopAccentColor;
+ 
+ typedef enum {
+diff --git a/schemas/org.gnome.desktop.interface.gschema.xml.in b/schemas/org.gnome.desktop.interface.gschema.xml.in
+index b3150ed..53daefa 100644
+--- a/schemas/org.gnome.desktop.interface.gschema.xml.in
++++ b/schemas/org.gnome.desktop.interface.gschema.xml.in
+@@ -315,7 +315,7 @@
+       <default>'blue'</default>
+       <summary>Accent color</summary>
+       <description>
+-        The preferred accent color for the user interface. Valid values are "blue", "teal", "green", "yellow", "orange", "red", "pink", "purple", "slate".
++        The preferred accent color for the user interface. Valid values are "blue", "teal", "green", "yellow", "orange", "red", "pink", "purple", "slate", "brown".
+       </description>
+     </key>
+   </schema>

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -650,7 +650,12 @@ parts:
     source-type: git
     source-tag: 'applied/1.9.0-0ubuntu1'
     source-depth: 1
-    after: [ meson-deps, gtk4, vala, gobject-introspection ]
+    after:
+      - meson-deps
+      - gtk4
+      - vala
+      - gobject-introspection
+      - gsettings-desktop-schemas
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -893,6 +898,12 @@ parts:
       - -Ddebug=true
       - -Dintrospection=true
     build-environment: *buildenv
+    override-pull: |
+      set -eux
+      craftctl default
+      for patch in $CRAFT_PROJECT_DIR/patches/gsettings-desktop-schemas/*.patch; do
+        patch -p1 < "$patch"
+      done
     override-build: |
       set -eux
       craftctl default

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -881,7 +881,7 @@ parts:
   gsettings-desktop-schemas:
     after: [ gsound, meson-deps, gobject-introspection ]
     source: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas.git
-    source-tag: '46.1'
+    source-tag: '50.1'
 # ext:updatesnap
 #   version-format:
 #     same-major: true


### PR DESCRIPTION
We used to compile the settings schemas without accent brown accent color support, thus snaps might be not aware of it.

Also make libadwaita to depend on this, since it uses the GDesktopAccentColor enum.